### PR TITLE
Improve dashboard card hover effect

### DIFF
--- a/app/src/main/resources/templates/dashboard.html
+++ b/app/src/main/resources/templates/dashboard.html
@@ -99,11 +99,12 @@
             box-shadow: 0 4px 8px rgba(0,0,0,0.2);
             color: white;
             border: 1px solid rgba(255,255,255,0.1);
-            transition: transform 0.3s ease;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
         }
 
         .card:hover {
-            transform: translateY(-5px);
+            transform: translateY(-5px) scale(1.05);
+            box-shadow: 0 8px 16px rgba(0,0,0,0.3);
         }
 
         .card p {


### PR DESCRIPTION
## Summary
- add scale and shadow effect when hovering over dashboard cards

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685b3b1dea008322a28dd500a4486f8e