### PR TITLE
Revamp meteorological report UI

### DIFF
--- a/app/src/main/resources/templates/reportes.html
+++ b/app/src/main/resources/templates/reportes.html
@@ -1,169 +1,112 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-  <meta charset="UTF-8" />
-  <title>Reportes – Dashboard Meteorológico</title>
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet" />
-  <style>
-    * { margin:0; padding:0; box-sizing:border-box; font-family:'Roboto',sans-serif; }
-    body { display:flex; min-height:100vh; background-color:#f4f6f9; }
-    .sidebar{ width:230px;background-color:#1a3f78;color:white;padding:20px; }
-    .sidebar h2{ font-size:20px;margin-bottom:30px; }
-    .sidebar nav a{ color:white;text-decoration:none;display:block;margin:10px 0;padding:10px;border-radius:5px; }
-    .sidebar nav a:hover{ background-color:#2a4d90; }
-    .sidebar nav a.actual{ background-color:#2a4d90; }
-    .logout-form{ margin-top:20px; }
-    .logout-form button{ width:100%;background-color:#dc3545;color:white;border:none;border-radius:5px;padding:10px;cursor:pointer;font-weight:bold; }
-    .content{ flex:1;padding:30px; }
-    .content h1{ color:#1a3f78;margin-bottom:20px; }
-    .tablas{ display:flex;flex-wrap:wrap;gap:20px;margin-top:20px; }
-    .tabla{ background:white;border-radius:10px;padding:20px;flex:1;min-width:300px;box-shadow:0 2px 4px rgba(0,0,0,0.1); }
-    .tabla h3{ color:#1a3f78;margin-bottom:10px; }
-    .tabla table{ width:100%;border-collapse:collapse; }
-    .tabla th,.tabla td{ border:1px solid #ddd;padding:8px;font-size:14px; }
-    .tabla th{ background-color:#f0f0f0; }
-    button{ background-color:#1a3f78;color:white;border:none;border-radius:4px;padding:8px 16px;cursor:pointer; }
-    label{ margin-right:8px;font-weight:bold;color:#1a3f78; }
-    input[type=date]{ padding:6px;border:1px solid #ccc;border-radius:4px; }
-    .pagination{ margin-top:20px;display:flex;align-items:center;flex-wrap:wrap;gap:10px; }
-    .pagination a,.pagination span{ padding:6px 12px;background:white;border:1px solid #ccc;border-radius:4px;text-decoration:none;color:black; }
-    .pagination .actual{ background-color:#007b00;color:white;font-weight:bold; }
-  </style>
+    <meta charset="UTF-8" />
+    <title>Reportes – Dashboard Meteorológico</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet" />
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; font-family: 'Roboto', sans-serif; }
+        body { display: flex; min-height: 100vh; background-color: #f4f6f9; }
+        .sidebar { width: 230px; background-color: #1a3f78; color: white; padding: 20px; }
+        .sidebar h2 { font-size: 20px; margin-bottom: 30px; }
+        .sidebar nav a { color: white; text-decoration: none; display: block; margin: 10px 0; padding: 10px; border-radius: 5px; }
+        .sidebar nav a:hover { background-color: #2a4d90; }
+        .sidebar nav a.actual { background-color: #2a4d90; }
+        .logout-form { margin-top: 20px; }
+        .logout-form button { width: 100%; background-color: #dc3545; color: white; border: none; border-radius: 5px; padding: 10px; cursor: pointer; font-weight: bold; }
+
+        .content { flex: 1; padding: 30px; }
+        .content h1 { color: #1a3f78; margin-bottom: 5px; }
+        .content .subtitle { color: #555; margin-bottom: 25px; }
+
+        .report-generator { background: white; border-radius: 10px; padding: 20px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); max-width: 500px; margin-bottom: 30px; }
+        .report-generator form { display: flex; flex-wrap: wrap; gap: 15px; align-items: center; }
+        .report-generator label { margin-right: 8px; font-weight: bold; color: #1a3f78; }
+        .report-generator select, .report-generator input[type=date] { padding: 8px; border: 1px solid #ccc; border-radius: 4px; flex: 1; min-width: 160px; }
+        .report-generator button { background-color: #007bff; color: white; border: none; border-radius: 4px; padding: 8px 16px; cursor: pointer; }
+
+        .recent-reports { margin-top: 10px; }
+        .recent-reports h2 { color: #1a3f78; margin-bottom: 10px; }
+        .report-item { background: white; border-radius: 6px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); padding: 10px 15px; display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; }
+        .report-info { display: flex; flex-direction: column; }
+        .report-title { font-weight: bold; color: #333; }
+        .report-station { font-size: 14px; color: #555; }
+        .download-btn { color: #1a3f78; text-decoration: none; font-size: 20px; }
+
+        @media(max-width: 600px) {
+            .report-generator form { flex-direction: column; align-items: stretch; }
+        }
+    </style>
 </head>
 <body>
-
-  <div class="sidebar">
-    <h2>Menú</h2>
-    <nav>
-      <a th:href="@{/}">Dashboard</a>
-      <a th:href="@{/estaciones}">Estaciones Meteorológicas</a>
-      <a th:href="@{/alertas}">Alertas</a>
-      <a th:href="@{/reportes}" class="actual">Reportes</a>
-      <a th:href="@{/tablas}">Tablas</a>
-    </nav>
-    <form class="logout-form" th:action="@{/logout}" method="post">
-      <button type="submit">Cerrar sesión</button>
-    </form>
-  </div>
-
-  <div class="content">
-    <h1>Reportes por Fecha</h1>
-
-    <form method="get" th:action="@{/reportes}" style="margin-bottom:20px;">
-      <label for="fecha">Fecha:</label>
-      <input type="date" id="fecha" name="fecha" th:value="${fecha}" />
-      <input type="hidden" name="pagina" value="0" />
-      <input type="hidden" name="tamanoPagina" th:value="${tamanoPagina}" />
-      <button type="submit">Generar</button>
-    </form>
-
-    <div th:if="${fecha != null}" class="tablas">
-      <div class="tabla">
-        <h3>Velocidad del Viento</h3>
-        <table>
-          <thead><tr><th>ID</th><th>Velocidad</th><th>Fecha</th></tr></thead>
-          <tbody>
-            <tr th:each="v : ${velocidades}">
-              <td th:text="${v.id}"></td>
-              <td th:text="${v.velocidad}"></td>
-              <td th:text="${v.fecha}"></td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <div class="tabla">
-        <h3>Dirección del Viento</h3>
-        <table>
-          <thead><tr><th>ID</th><th>Dirección</th><th>Fecha</th></tr></thead>
-          <tbody>
-            <tr th:each="d : ${direcciones}">
-              <td th:text="${d.id}"></td>
-              <td th:text="${d.direccion}"></td>
-              <td th:text="${d.fecha}"></td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <div class="tabla">
-        <h3>Precipitación</h3>
-        <table>
-          <thead><tr><th>ID</th><th>mm</th><th>Fecha</th></tr></thead>
-          <tbody>
-            <tr th:each="p : ${precipitaciones}">
-              <td th:text="${p.id}"></td>
-              <td th:text="${#numbers.formatDecimal(p.probabilidad,1,1)}"></td>
-              <td th:text="${p.fecha}"></td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <div class="tabla">
-        <h3>Humedad</h3>
-        <table>
-          <thead><tr><th>ID</th><th>%</th><th>Fecha</th></tr></thead>
-          <tbody>
-            <tr th:each="h : ${humedades}">
-              <td th:text="${h.id}"></td>
-              <td th:text="${h.humedad}"></td>
-              <td th:text="${h.fecha}"></td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <div class="tabla">
-        <h3>Temperatura</h3>
-        <table>
-          <thead><tr><th>ID</th><th>°C</th><th>Fecha</th></tr></thead>
-          <tbody>
-            <tr th:each="t : ${temperaturas}">
-              <td th:text="${t.id}"></td>
-              <td th:text="${t.temperatura}"></td>
-              <td th:text="${t.fecha}"></td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+    <div class="sidebar">
+        <h2>Menú</h2>
+        <nav>
+            <a th:href="@{/}">Dashboard</a>
+            <a th:href="@{/estaciones}">Estaciones Meteorológicas</a>
+            <a th:href="@{/alertas}">Alertas</a>
+            <a th:href="@{/reportes}" class="actual">Reportes</a>
+            <a th:href="@{/tablas}">Tablas</a>
+        </nav>
+        <form class="logout-form" th:action="@{/logout}" method="post">
+            <button type="submit">Cerrar sesión</button>
+        </form>
     </div>
 
-    <div th:if="${fecha != null}" class="pagination">
-      <span th:text="'Página ' + (${paginaActual} + 1) + ' de ' + ${velocidades.totalPages}"></span>
+    <div class="content">
+        <h1>Reportes</h1>
+        <p class="subtitle">Generación de reportes y análisis</p>
 
-      <a th:if="${paginaActual > 0}"
-         th:href="@{/reportes(fecha=${fecha}, pagina=0, tamanoPagina=${tamanoPagina})}">&laquo;</a>
-      <a th:if="${paginaActual > 0}"
-         th:href="@{/reportes(fecha=${fecha}, pagina=${paginaActual - 1}, tamanoPagina=${tamanoPagina})}">&lt;</a>
+        <div class="report-generator">
+            <form method="get" th:action="@{/reportes}">
+                <label for="fecha">Fecha:</label>
+                <input type="date" id="fecha" name="fecha" />
 
-      <span th:each="i : ${#numbers.sequence(0, velocidades.totalPages - 1)}"
-            th:if="${i >= paginaActual - 2 && i <= paginaActual + 2}"
-            th:classappend="${i == paginaActual}? 'actual'">
-        <a th:if="${i != paginaActual}"
-           th:href="@{/reportes(fecha=${fecha}, pagina=${i}, tamanoPagina=${tamanoPagina})}"
-           th:text="${i + 1}"></a>
-        <span th:if="${i == paginaActual}" th:text="${i + 1}"></span>
-      </span>
+                <label for="estacion">Estación:</label>
+                <select id="estacion" name="estacion">
+                    <option value="all">Todas las estaciones</option>
+                    <option>Estación1</option>
+                    <option>Estación2</option>
+                </select>
 
-      <a th:if="${paginaActual + 1 < velocidades.totalPages}"
-         th:href="@{/reportes(fecha=${fecha}, pagina=${paginaActual + 1}, tamanoPagina=${tamanoPagina})}">&gt;</a>
-      <a th:if="${paginaActual + 1 < velocidades.totalPages}"
-         th:href="@{/reportes(fecha=${fecha}, pagina=${velocidades.totalPages - 1}, tamanoPagina=${tamanoPagina})}">&raquo;</a>
+                <label for="tipo">Tipo:</label>
+                <select id="tipo" name="tipo">
+                    <option value="diario">Diario</option>
+                    <option value="semanal">Semanal</option>
+                    <option value="mensual">Mensual</option>
+                </select>
 
-      <form method="get" th:action="@{/reportes}" style="display:inline; margin-left:10px;">
-        <input type="hidden" name="fecha" th:value="${fecha}" />
-        <label>Registros por página:</label>
-        <select name="tamanoPagina" onchange="this.form.submit()">
-          <option th:value="10"  th:selected="${tamanoPagina==10}">10</option>
-          <option th:value="20"  th:selected="${tamanoPagina==20}">20</option>
-          <option th:value="50"  th:selected="${tamanoPagina==50}">50</option>
-          <option th:value="100" th:selected="${tamanoPagina==100}">100</option>
-        </select>
-        <input type="hidden" name="pagina" th:value="${paginaActual}" />
-      </form>
+                <button type="submit">Generar Reporte</button>
+            </form>
+        </div>
+
+        <div class="recent-reports">
+            <h2>Reportes Recientes</h2>
+
+            <div class="report-item">
+                <div class="report-info">
+                    <span class="report-title">Reporte Diario - 2023-12-14</span>
+                    <span class="report-station">Todas las estaciones</span>
+                </div>
+                <a href="#" class="download-btn">&#x2B07;</a>
+            </div>
+
+            <div class="report-item">
+                <div class="report-info">
+                    <span class="report-title">Reporte Semanal - 2023-12-11 a 2023-12-17</span>
+                    <span class="report-station">Estación1</span>
+                </div>
+                <a href="#" class="download-btn">&#x2B07;</a>
+            </div>
+
+            <div class="report-item">
+                <div class="report-info">
+                    <span class="report-title">Reporte Mensual - Noviembre 2023</span>
+                    <span class="report-station">Estación2</span>
+                </div>
+                <a href="#" class="download-btn">&#x2B07;</a>
+            </div>
+        </div>
     </div>
-
-  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redesign `reportes.html` with modern layout
- add report generator form for date, station, and type
- show sample recent reports list with download icons

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685c35164a4c8322b4eb943017c68d82