### PR TITLE
Add sidebar fragment with new styles

### DIFF
--- a/app/src/main/resources/static/css/sidebar.css
+++ b/app/src/main/resources/static/css/sidebar.css
@@ -1,0 +1,93 @@
+@import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap');
+
+:root {
+    --sidebar-bg: #1E40AF;
+    --sidebar-hover-bg: #2563EB;
+    --sidebar-accent: #FBBF24;
+    --logout-bg: #EF4444;
+    --text-color: #ffffff;
+    --transition-speed: 0.2s;
+}
+
+.sidebar {
+    width: 250px;
+    background-color: var(--sidebar-bg);
+    padding: 1rem;
+    color: var(--text-color);
+    font-family: 'Poppins', sans-serif;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.sidebar-header {
+    display: flex;
+    align-items: center;
+    font-weight: 700;
+    font-size: 16px;
+    border-bottom: 1px solid rgba(255,255,255,0.1);
+    padding-bottom: 1rem;
+    margin-bottom: 1rem;
+}
+
+.sidebar-header i {
+    margin-right: 0.5rem;
+}
+
+.sidebar-menu {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    flex-grow: 1;
+}
+
+.sidebar-menu li {
+    margin-bottom: 0.25rem;
+}
+
+.sidebar-menu a {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--text-color);
+    text-decoration: none;
+    font-size: 14px;
+    padding: 0.5rem;
+    border-left: 4px solid transparent;
+    transition: background-color var(--transition-speed), border-left-color var(--transition-speed);
+}
+
+.sidebar-menu a:hover,
+.sidebar-menu a.active {
+    background-color: var(--sidebar-hover-bg);
+    border-left-color: var(--sidebar-accent);
+}
+
+.sidebar-footer {
+    font-size: 12px;
+}
+
+.sidebar-footer form {
+    margin-top: 0.5rem;
+}
+
+.logout-btn {
+    width: 100%;
+    padding: 0.5rem;
+    border: none;
+    background-color: var(--logout-bg);
+    color: var(--text-color);
+    border-radius: 0.375rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    transition: background-color var(--transition-speed);
+    font-size: 14px;
+}
+
+.logout-btn:hover {
+    background-color: #dc2626;
+}

--- a/app/src/main/resources/templates/sidebar.html
+++ b/app/src/main/resources/templates/sidebar.html
@@ -1,0 +1,53 @@
+<div th:fragment="sidebar(activeMenu)">
+    <aside class="sidebar">
+        <div>
+            <header class="sidebar-header">
+                <i class="fas fa-cloud"></i>
+                <span>MeteoSystem v2.0</span>
+            </header>
+            <nav>
+                <ul class="sidebar-menu">
+                    <li>
+                        <a th:href="@{/}" th:classappend="${activeMenu=='dashboard'} ? 'active'">
+                            <i class="fas fa-chart-bar"></i>
+                            <span>Dashboard</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a th:href="@{/estaciones}" th:classappend="${activeMenu=='estaciones'} ? 'active'">
+                            <i class="fas fa-broadcast-tower"></i>
+                            <span>Estaciones Meteorológicas</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a th:href="@{/alertas}" th:classappend="${activeMenu=='alertas'} ? 'active'">
+                            <i class="fas fa-exclamation-triangle"></i>
+                            <span>Alertas</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a th:href="@{/reportes}" th:classappend="${activeMenu=='reportes'} ? 'active'">
+                            <i class="fas fa-chart-line"></i>
+                            <span>Reportes</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a th:href="@{/tablas}" th:classappend="${activeMenu=='tablas'} ? 'active'">
+                            <i class="fas fa-table"></i>
+                            <span>Tablas</span>
+                        </a>
+                    </li>
+                </ul>
+            </nav>
+        </div>
+        <footer class="sidebar-footer">
+            <p>Conectado como: admin</p>
+            <form th:action="@{/logout}" method="post">
+                <button type="submit" class="logout-btn">
+                    <i class="fas fa-sign-out-alt"></i>
+                    <span>Cerrar sesión</span>
+                </button>
+            </form>
+        </footer>
+    </aside>
+</div>


### PR DESCRIPTION
## Summary
- add `sidebar.html` fragment containing menu items and logout button
- apply new styles in `sidebar.css` with FontAwesome icons, Google Fonts, and hover effects

## Testing
- `sh gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685d66000dd88322afd8368996f0331c