### PR TITLE
Actualiza roles de usuarios

### DIFF
--- a/app/src/main/java/org/javadominicano/configuracion/SeguridadConfig.java
+++ b/app/src/main/java/org/javadominicano/configuracion/SeguridadConfig.java
@@ -21,7 +21,8 @@ public class SeguridadConfig {
         http
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/login", "/css/**", "/js/**").permitAll()
-                .anyRequest().authenticated()
+                .requestMatchers("/", "/dashboard", "/api/datos-meteorologicos").hasAnyRole("USER", "ADMIN")
+                .anyRequest().hasRole("ADMIN")
             )
             .formLogin(form -> form
                 .loginPage("/login")
@@ -45,7 +46,7 @@ public class SeguridadConfig {
         UserDetails dariel = User.builder()
             .username("dariel")
             .password(encodedDariel)
-            .roles("USER")
+            .roles("ADMIN")
             .build();
 
         // Usuario Scarlet

--- a/app/src/main/resources/templates/dashboard.html
+++ b/app/src/main/resources/templates/dashboard.html
@@ -329,6 +329,18 @@
             text-align: center;
         }
 
+        .info-bar-message.success {
+            color: #28a745;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            gap: 5px;
+        }
+
+        .info-bar-message.success .checkmark {
+            font-size: 18px;
+        }
+
         .info-bar-message.inactive {
             color: #a00;
         }
@@ -509,19 +521,20 @@
     <div class="info-bar">
         <div class="section">
             <div class="number" th:text="${#lists.size(estaciones)}">0</div>
-            <div class="label">Total</div>
+            <div class="label">Total de estaciones</div>
         </div>
         <div class="section">
             <div class="number" th:text="${estacionesActivas}">0</div>
-            <div class="label">Activas</div>
+            <div class="label">Estaciones activas</div>
         </div>
         <div class="section">
             <div class="number" th:text="${estacionesInactivas}">0</div>
-            <div class="label">Inactivas</div>
+            <div class="label">Estaciones inactivas</div>
         </div>
     </div>
-    <div th:if="${estacionesInactivas == 0}" class="info-bar-message">
-        Todas las estaciones están comunicando
+    <div th:if="${estacionesInactivas == 0}" class="info-bar-message success">
+        <span class="checkmark">&#10004;</span>
+        <strong>Todas las estaciones están comunicando</strong>
     </div>
     <div th:if="${estacionesInactivas > 0}" class="info-bar-message inactive" th:text="'Hay una estación que no está comunicando (' + ${estacionesInactivasList.get(0).id} + ')'">
         Hay una estación que no está comunicando (EST001)


### PR DESCRIPTION
## Summary
- asigna rol ADMIN al usuario dariel y deja a scarlet como USER
- limita el acceso a rutas administrativas para usuarios con rol ADMIN

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685dd3b092b8832294432441e82b9d89