### PR TITLE
Hide admin menu for regular users

### DIFF
--- a/app/src/main/java/org/javadominicano/configuracion/GlobalAttributes.java
+++ b/app/src/main/java/org/javadominicano/configuracion/GlobalAttributes.java
@@ -1,0 +1,23 @@
+package org.javadominicano.configuracion;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@ControllerAdvice
+public class GlobalAttributes {
+
+    @ModelAttribute("esAdmin")
+    public boolean esAdmin(Authentication auth) {
+        if (auth == null) {
+            return false;
+        }
+        for (GrantedAuthority authority : auth.getAuthorities()) {
+            if ("ROLE_ADMIN".equals(authority.getAuthority())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/app/src/main/resources/templates/dashboard.html
+++ b/app/src/main/resources/templates/dashboard.html
@@ -355,10 +355,10 @@
     <nav>
         <ul>
             <li><a th:href="@{/}"><i class="fas fa-chart-bar"></i><span>Dashboard</span></a></li>
-            <li><a th:href="@{/estaciones}"><i class="fas fa-broadcast-tower"></i><span>Estaciones Meteorológicas</span></a></li>
-            <li><a href="#"><i class="fas fa-exclamation-triangle"></i><span>Alertas</span></a></li>
-            <li><a th:href="@{/reportes}"><i class="fas fa-chart-line"></i><span>Reportes</span></a></li>
-            <li><a th:href="@{/tablas}"><i class="fas fa-table"></i><span>Tablas</span></a></li>
+            <li th:if="${esAdmin}"><a th:href="@{/estaciones}"><i class="fas fa-broadcast-tower"></i><span>Estaciones Meteorológicas</span></a></li>
+            <li th:if="${esAdmin}"><a href="#"><i class="fas fa-exclamation-triangle"></i><span>Alertas</span></a></li>
+            <li th:if="${esAdmin}"><a th:href="@{/reportes}"><i class="fas fa-chart-line"></i><span>Reportes</span></a></li>
+            <li th:if="${esAdmin}"><a th:href="@{/tablas}"><i class="fas fa-table"></i><span>Tablas</span></a></li>
         </ul>
     </nav>
     <form class="logout-form" th:action="@{/logout}" method="post" style="margin-top: 20px;">

--- a/app/src/main/resources/templates/estaciones.html
+++ b/app/src/main/resources/templates/estaciones.html
@@ -64,10 +64,10 @@
     <nav>
         <ul>
             <li><a th:href="@{/}"><i class="fas fa-chart-bar"></i><span>Dashboard</span></a></li>
-            <li><a th:href="@{/estaciones}" class="actual"><i class="fas fa-broadcast-tower"></i><span>Estaciones Meteorológicas</span></a></li>
-            <li><a href="#"><i class="fas fa-exclamation-triangle"></i><span>Alertas</span></a></li>
-            <li><a th:href="@{/reportes}"><i class="fas fa-chart-line"></i><span>Reportes</span></a></li>
-            <li><a th:href="@{/tablas}"><i class="fas fa-table"></i><span>Tablas</span></a></li>
+            <li th:if="${esAdmin}"><a th:href="@{/estaciones}" class="actual"><i class="fas fa-broadcast-tower"></i><span>Estaciones Meteorológicas</span></a></li>
+            <li th:if="${esAdmin}"><a href="#"><i class="fas fa-exclamation-triangle"></i><span>Alertas</span></a></li>
+            <li th:if="${esAdmin}"><a th:href="@{/reportes}"><i class="fas fa-chart-line"></i><span>Reportes</span></a></li>
+            <li th:if="${esAdmin}"><a th:href="@{/tablas}"><i class="fas fa-table"></i><span>Tablas</span></a></li>
         </ul>
     </nav>
     <form class="logout-form" th:action="@{/logout}" method="post">

--- a/app/src/main/resources/templates/reportePreview.html
+++ b/app/src/main/resources/templates/reportePreview.html
@@ -36,10 +36,10 @@
         <nav>
             <ul>
                 <li><a th:href="@{/}"><i class="fas fa-chart-bar"></i><span>Dashboard</span></a></li>
-                <li><a th:href="@{/estaciones}"><i class="fas fa-broadcast-tower"></i><span>Estaciones Meteorológicas</span></a></li>
-                <li><a th:href="@{/alertas}"><i class="fas fa-exclamation-triangle"></i><span>Alertas</span></a></li>
-                <li><a th:href="@{/reportes}" class="actual"><i class="fas fa-chart-line"></i><span>Reportes</span></a></li>
-                <li><a th:href="@{/tablas}"><i class="fas fa-table"></i><span>Tablas</span></a></li>
+                <li th:if="${esAdmin}"><a th:href="@{/estaciones}"><i class="fas fa-broadcast-tower"></i><span>Estaciones Meteorológicas</span></a></li>
+                <li th:if="${esAdmin}"><a th:href="@{/alertas}"><i class="fas fa-exclamation-triangle"></i><span>Alertas</span></a></li>
+                <li th:if="${esAdmin}"><a th:href="@{/reportes}" class="actual"><i class="fas fa-chart-line"></i><span>Reportes</span></a></li>
+                <li th:if="${esAdmin}"><a th:href="@{/tablas}"><i class="fas fa-table"></i><span>Tablas</span></a></li>
             </ul>
         </nav>
         <form class="logout-form" th:action="@{/logout}" method="post">

--- a/app/src/main/resources/templates/reportes.html
+++ b/app/src/main/resources/templates/reportes.html
@@ -87,10 +87,10 @@
         <nav>
             <ul>
                 <li><a th:href="@{/}"><i class="fas fa-chart-bar"></i><span>Dashboard</span></a></li>
-                <li><a th:href="@{/estaciones}"><i class="fas fa-broadcast-tower"></i><span>Estaciones Meteorológicas</span></a></li>
-                <li><a th:href="@{/alertas}"><i class="fas fa-exclamation-triangle"></i><span>Alertas</span></a></li>
-                <li><a th:href="@{/reportes}" class="actual"><i class="fas fa-chart-line"></i><span>Reportes</span></a></li>
-                <li><a th:href="@{/tablas}"><i class="fas fa-table"></i><span>Tablas</span></a></li>
+                <li th:if="${esAdmin}"><a th:href="@{/estaciones}"><i class="fas fa-broadcast-tower"></i><span>Estaciones Meteorológicas</span></a></li>
+                <li th:if="${esAdmin}"><a th:href="@{/alertas}"><i class="fas fa-exclamation-triangle"></i><span>Alertas</span></a></li>
+                <li th:if="${esAdmin}"><a th:href="@{/reportes}" class="actual"><i class="fas fa-chart-line"></i><span>Reportes</span></a></li>
+                <li th:if="${esAdmin}"><a th:href="@{/tablas}"><i class="fas fa-table"></i><span>Tablas</span></a></li>
             </ul>
         </nav>
         <form class="logout-form" th:action="@{/logout}" method="post">

--- a/app/src/main/resources/templates/tablas.html
+++ b/app/src/main/resources/templates/tablas.html
@@ -45,10 +45,10 @@
     <nav>
       <ul>
         <li><a th:href="@{/}"><i class="fas fa-chart-bar"></i><span>Dashboard</span></a></li>
-        <li><a th:href="@{/estaciones}"><i class="fas fa-broadcast-tower"></i><span>Estaciones Meteorológicas</span></a></li>
-        <li><a th:href="@{/alertas}"><i class="fas fa-exclamation-triangle"></i><span>Alertas</span></a></li>
-        <li><a th:href="@{/reportes}"><i class="fas fa-chart-line"></i><span>Reportes</span></a></li>
-        <li><a th:href="@{/tablas}" class="actual"><i class="fas fa-table"></i><span>Tablas</span></a></li>
+        <li th:if="${esAdmin}"><a th:href="@{/estaciones}"><i class="fas fa-broadcast-tower"></i><span>Estaciones Meteorológicas</span></a></li>
+        <li th:if="${esAdmin}"><a th:href="@{/alertas}"><i class="fas fa-exclamation-triangle"></i><span>Alertas</span></a></li>
+        <li th:if="${esAdmin}"><a th:href="@{/reportes}"><i class="fas fa-chart-line"></i><span>Reportes</span></a></li>
+        <li th:if="${esAdmin}"><a th:href="@{/tablas}" class="actual"><i class="fas fa-table"></i><span>Tablas</span></a></li>
       </ul>
     </nav>
     <form class="logout-form" th:action="@{/logout}" method="post">


### PR DESCRIPTION
## Summary
- add GlobalAttributes to expose `esAdmin` to views
- show Estaciones, Alertas, Reportes and Tablas menu items only for admins

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685de996a17483228ab08b9540c4ad1a