### PR TITLE
Fix decimal parsing for alerts

### DIFF
--- a/app/src/main/java/org/javadominicano/configuracion/GlobalBindingConfig.java
+++ b/app/src/main/java/org/javadominicano/configuracion/GlobalBindingConfig.java
@@ -1,0 +1,28 @@
+package com.javadominicano.configuracion;
+
+import java.beans.PropertyEditorSupport;
+
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.InitBinder;
+
+@ControllerAdvice
+public class GlobalBindingConfig {
+    @InitBinder
+    public void initBinder(WebDataBinder binder) {
+        PropertyEditorSupport doubleEditor = new PropertyEditorSupport() {
+            @Override
+            public void setAsText(String text) {
+                if (text == null || text.isBlank()) {
+                    setValue(null);
+                    return;
+                }
+                text = text.replace(',', '.');
+                setValue(Double.parseDouble(text));
+            }
+        };
+
+        binder.registerCustomEditor(Double.class, doubleEditor);
+        binder.registerCustomEditor(double.class, doubleEditor);
+    }
+}

--- a/app/src/main/java/org/javadominicano/entidades/Alerta.java
+++ b/app/src/main/java/org/javadominicano/entidades/Alerta.java
@@ -13,11 +13,11 @@ public class Alerta {
 
     private double umbral;
 
-    private boolean activa = true;
+    private boolean activa;
 
-    private String operador = ">";
+    private String operador;
 
-    private String prioridad = "Media";
+    private String prioridad;
 
     public Long getId() {
         return id;


### PR DESCRIPTION
## Summary
- remove default values from `Alerta` entity
- add controller advice to parse decimals using comma or dot

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6860feb43fa08322be06f03f39802dbb