### PR TITLE
Improve Alertas page with active alerts list

### DIFF
--- a/app/src/main/java/org/javadominicano/controladores/AlertasController.java
+++ b/app/src/main/java/org/javadominicano/controladores/AlertasController.java
@@ -2,7 +2,16 @@ package org.javadominicano.controladores;
 
 import org.javadominicano.entidades.Alerta;
 import org.javadominicano.repositorios.RepositorioAlerta;
+import org.javadominicano.repositorios.RepositorioDatosPrecipitacion;
+import org.javadominicano.repositorios.RepositorioDatosVelocidad;
+import org.javadominicano.visualizadorweb.repositorios.RepositorioDatosHumedad;
+import org.javadominicano.visualizadorweb.repositorios.RepositorioDatosTemperatura;
 import org.javadominicano.visualizadorweb.entidades.Umbrales;
+import org.javadominicano.entidades.DatosPrecipitacion;
+import org.javadominicano.entidades.DatosVelocidad;
+import org.javadominicano.visualizadorweb.entidades.DatosHumedad;
+import org.javadominicano.visualizadorweb.entidades.DatosTemperatura;
+import org.javadominicano.dto.AlertaActivaDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -10,12 +19,29 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.data.domain.PageRequest;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
 
 @Controller
 public class AlertasController {
 
     @Autowired
     private RepositorioAlerta repoAlerta;
+
+    @Autowired
+    private RepositorioDatosVelocidad repoVelocidad;
+
+    @Autowired
+    private RepositorioDatosHumedad repoHumedad;
+
+    @Autowired
+    private RepositorioDatosTemperatura repoTemperatura;
+
+    @Autowired
+    private RepositorioDatosPrecipitacion repoPrecipitacion;
 
     @ModelAttribute("umbrales")
     public Umbrales obtenerUmbrales() {
@@ -36,6 +62,10 @@ public class AlertasController {
     public String listarAlertas(Model model) {
         model.addAttribute("alertas", repoAlerta.findAll());
         model.addAttribute("nuevaAlerta", new Alerta());
+
+        List<AlertaActivaDTO> activas = obtenerAlertasActivas();
+        model.addAttribute("alertasActivas", activas);
+
         return "alertas";
     }
 
@@ -49,5 +79,42 @@ public class AlertasController {
     public String eliminarAlerta(@RequestParam Long id) {
         repoAlerta.deleteById(id);
         return "redirect:/alertas";
+    }
+
+    private List<AlertaActivaDTO> obtenerAlertasActivas() {
+        List<AlertaActivaDTO> lista = new ArrayList<>();
+
+        DatosTemperatura temp = repoTemperatura.findTopByOrderByFechaDesc(PageRequest.of(0, 1)).get(0);
+        DatosHumedad hum = repoHumedad.findTopByOrderByFechaDesc(PageRequest.of(0, 1)).get(0);
+        DatosVelocidad vel = repoVelocidad.findTopByOrderByFechaDesc(PageRequest.of(0, 1)).get(0);
+        DatosPrecipitacion pre = repoPrecipitacion.findTopByOrderByFechaDesc(PageRequest.of(0, 1)).get(0);
+
+        agregarAlertaActiva(lista, repoAlerta.findByNombre("Temperatura"), temp.getTemperatura(), temp.getFecha());
+        agregarAlertaActiva(lista, repoAlerta.findByNombre("Humedad"), hum.getHumedad(), hum.getFecha());
+        agregarAlertaActiva(lista, repoAlerta.findByNombre("VelocidadViento"), vel.getVelocidad(), vel.getFecha());
+        agregarAlertaActiva(lista, repoAlerta.findByNombre("Precipitacion"), pre.getProbabilidad(), pre.getFecha());
+
+        return lista;
+    }
+
+    private void agregarAlertaActiva(List<AlertaActivaDTO> lista, Alerta alerta, double valor, Timestamp fecha) {
+        if (chequearAlerta(alerta, valor)) {
+            AlertaActivaDTO dto = new AlertaActivaDTO();
+            dto.setAlerta(alerta);
+            dto.setValorActual(valor);
+            dto.setFecha(fecha);
+            lista.add(dto);
+        }
+    }
+
+    private boolean chequearAlerta(Alerta alerta, Double valor) {
+        if (alerta == null || valor == null || !alerta.isActiva()) {
+            return false;
+        }
+        if (">".equals(alerta.getOperador())) {
+            return valor > alerta.getUmbral();
+        } else {
+            return valor < alerta.getUmbral();
+        }
     }
 }

--- a/app/src/main/java/org/javadominicano/controladores/AlertasController.java
+++ b/app/src/main/java/org/javadominicano/controladores/AlertasController.java
@@ -81,6 +81,12 @@ public class AlertasController {
         return "redirect:/alertas";
     }
 
+    @PostMapping("/alertas/eliminar-todas")
+    public String eliminarTodas() {
+        repoAlerta.deleteAll();
+        return "redirect:/alertas";
+    }
+
     private List<AlertaActivaDTO> obtenerAlertasActivas() {
         List<AlertaActivaDTO> lista = new ArrayList<>();
 

--- a/app/src/main/java/org/javadominicano/dto/AlertaActivaDTO.java
+++ b/app/src/main/java/org/javadominicano/dto/AlertaActivaDTO.java
@@ -1,0 +1,35 @@
+package org.javadominicano.dto;
+
+import org.javadominicano.entidades.Alerta;
+
+import java.sql.Timestamp;
+
+public class AlertaActivaDTO {
+    private Alerta alerta;
+    private double valorActual;
+    private Timestamp fecha;
+
+    public Alerta getAlerta() {
+        return alerta;
+    }
+
+    public void setAlerta(Alerta alerta) {
+        this.alerta = alerta;
+    }
+
+    public double getValorActual() {
+        return valorActual;
+    }
+
+    public void setValorActual(double valorActual) {
+        this.valorActual = valorActual;
+    }
+
+    public Timestamp getFecha() {
+        return fecha;
+    }
+
+    public void setFecha(Timestamp fecha) {
+        this.fecha = fecha;
+    }
+}

--- a/app/src/main/resources/templates/alertas.html
+++ b/app/src/main/resources/templates/alertas.html
@@ -172,41 +172,6 @@
             </div>
         </div>
     </div>
-    <div class="cards">
-        <div class="alert-card" th:each="alerta : ${alertas}" th:classappend="${alerta.prioridad.toLowerCase()}">
-            <form th:action="@{/alertas/guardar}" method="post">
-                <input type="hidden" name="id" th:value="${alerta.id}" />
-                <input type="hidden" name="nombre" th:value="${alerta.nombre}" />
-                <label class="switch">
-                    <!-- Siempre enviar un valor para el campo activa -->
-                    <input type="hidden" name="activa" value="false" />
-                    <input type="checkbox" name="activa" value="true" th:checked="${alerta.activa}" onchange="this.form.submit()" />
-                    <span></span>
-                </label>
-                <h2 th:text="${alerta.nombre}">Alerta</h2>
-                <div class="row">
-                    <select name="operador" th:value="${alerta.operador}">
-                        <option value=">">Mayor que</option>
-                        <option value="<">Menor que</option>
-                    </select>
-                    <input type="number" step="0.1" name="umbral" th:value="${alerta.umbral}" required />
-                    <span th:text="${alerta.nombre == 'Temperatura' ? '°C' : alerta.nombre == 'Humedad' ? '%' : alerta.nombre == 'VelocidadViento' ? 'km/h' : 'mm'}"></span>
-                </div>
-                <select name="prioridad" th:value="${alerta.prioridad}">
-                    <option value="Alta">Alta</option>
-                    <option value="Media">Media</option>
-                    <option value="Baja">Baja</option>
-                </select>
-                <div class="row buttons">
-                    <button type="submit" class="btn btn-edit">Guardar</button>
-                    <button type="submit" th:attr="form='del__' + ${alerta.id}" class="btn btn-delete">Eliminar</button>
-                </div>
-            </form>
-            <form th:id="'del__' + ${alerta.id}" th:action="@{/alertas/eliminar}" method="post" onsubmit="return confirm('¿Eliminar alerta?');">
-                <input type="hidden" name="id" th:value="${alerta.id}" />
-            </form>
-        </div>
-    </div>
 </div>
 </body>
 </html>

--- a/app/src/main/resources/templates/alertas.html
+++ b/app/src/main/resources/templates/alertas.html
@@ -54,6 +54,33 @@
         .btn { padding: 6px 12px; border: none; border-radius: 4px; cursor: pointer; }
         .btn-edit { background-color: #007bff; color: white; }
         .btn-delete { background-color: #dc3545; color: white; }
+        /* Estilos para alertas activas */
+        .active-alerts {
+            background:white;
+            border-radius:8px;
+            box-shadow:0 2px 4px rgba(0,0,0,0.1);
+            padding:20px;
+            margin-bottom:40px;
+        }
+        .active-alerts h2 {
+            margin-bottom:15px;
+            color:#1a3f78;
+        }
+        .active-alert {
+            display:flex;
+            justify-content:space-between;
+            align-items:center;
+            padding:10px 0;
+            border-bottom:1px solid #eee;
+        }
+        .active-alert:last-child { border-bottom:none; }
+        .active-alert.high { border-left:4px solid #dc3545; padding-left:10px; }
+        .active-alert.medium { border-left:4px solid #ffc107; padding-left:10px; }
+        .active-alert.low { border-left:4px solid #28a745; padding-left:10px; }
+        .active-alert .info { font-weight:bold; }
+        .active-alert .fecha { font-size:14px; color:#666; margin-left:10px; }
+        .active-alert .acciones form { display:inline; }
+        .btn-toggle { background-color:#007bff; color:white; margin-right:5px; padding:6px 12px; border:none; border-radius:4px; cursor:pointer; }
         /* Estilos para la configuración de umbrales */
         .thresholds { display:flex; flex-wrap:wrap; gap:20px; margin-bottom:40px; }
         .threshold-card {
@@ -122,6 +149,29 @@
         </div>
         <button type="submit" class="btn btn-edit" style="align-self:flex-start;">Guardar</button>
     </form>
+
+    <div class="active-alerts" th:if="${alertasActivas != null}">
+        <h2>Alertas Activas (<span th:text="${alertasActivas.size()}"></span>)</h2>
+        <div th:each="aa : ${alertasActivas}" th:classappend=" ${aa.alerta.prioridad.toLowerCase()}" class="active-alert">
+            <div class="info" th:text="${aa.alerta.nombre + ': ' + #numbers.formatDecimal(aa.valorActual,1,1) + (aa.alerta.nombre == 'Temperatura' ? '°C' : aa.alerta.nombre == 'Humedad' ? '%' : aa.alerta.nombre == 'VelocidadViento' ? ' km/h' : ' mm') + ' (Umbral: ' + aa.alerta.umbral + (aa.alerta.nombre == 'Temperatura' ? '°C' : aa.alerta.nombre == 'Humedad' ? '%' : aa.alerta.nombre == 'VelocidadViento' ? ' km/h' : ' mm') + ')'}"></div>
+            <div class="fecha" th:text="${#temporals.format(aa.fecha.toInstant(), 'dd/MM/yyyy HH:mm')}"></div>
+            <div class="acciones">
+                <form th:action="@{/alertas/guardar}" method="post">
+                    <input type="hidden" name="id" th:value="${aa.alerta.id}" />
+                    <input type="hidden" name="nombre" th:value="${aa.alerta.nombre}" />
+                    <input type="hidden" name="operador" th:value="${aa.alerta.operador}" />
+                    <input type="hidden" name="umbral" th:value="${aa.alerta.umbral}" />
+                    <input type="hidden" name="prioridad" th:value="${aa.alerta.prioridad}" />
+                    <input type="hidden" name="activa" th:value="${!aa.alerta.activa}" />
+                    <button type="submit" class="btn-toggle" th:text="${aa.alerta.activa ? 'Desactivar' : 'Activar'}"></button>
+                </form>
+                <form th:action="@{/alertas/eliminar}" method="post" onsubmit="return confirm('¿Eliminar alerta?');">
+                    <input type="hidden" name="id" th:value="${aa.alerta.id}" />
+                    <button type="submit" class="btn-delete">Eliminar</button>
+                </form>
+            </div>
+        </div>
+    </div>
     <div class="cards">
         <div class="alert-card" th:each="alerta : ${alertas}" th:classappend="${alerta.prioridad.toLowerCase()}">
             <form th:action="@{/alertas/guardar}" method="post">

--- a/app/src/main/resources/templates/alertas.html
+++ b/app/src/main/resources/templates/alertas.html
@@ -56,31 +56,47 @@
         .btn-delete { background-color: #dc3545; color: white; }
         /* Estilos para alertas activas */
         .active-alerts {
-            background:white;
-            border-radius:8px;
-            box-shadow:0 2px 4px rgba(0,0,0,0.1);
-            padding:20px;
-            margin-bottom:40px;
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            padding: 20px;
+            margin-bottom: 40px;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
         }
         .active-alerts h2 {
-            margin-bottom:15px;
-            color:#1a3f78;
+            margin-bottom: 10px;
+            color: #1a3f78;
         }
         .active-alert {
-            display:flex;
-            justify-content:space-between;
-            align-items:center;
-            padding:10px 0;
-            border-bottom:1px solid #eee;
+            display: flex;
+            align-items: center;
+            gap: 20px;
+            padding: 12px 16px;
+            border-radius: 6px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+            background-color: #ffffff;
         }
-        .active-alert:last-child { border-bottom:none; }
-        .active-alert.high { border-left:4px solid #dc3545; padding-left:10px; }
-        .active-alert.medium { border-left:4px solid #ffc107; padding-left:10px; }
-        .active-alert.low { border-left:4px solid #28a745; padding-left:10px; }
-        .active-alert .info { font-weight:bold; }
-        .active-alert .fecha { font-size:14px; color:#666; margin-left:10px; }
-        .active-alert .acciones form { display:inline; }
-        .btn-toggle { background-color:#007bff; color:white; margin-right:5px; padding:6px 12px; border:none; border-radius:4px; cursor:pointer; }
+        .active-alert.high { border-left: 4px solid #dc3545; }
+        .active-alert.medium { border-left: 4px solid #ffc107; }
+        .active-alert.low { border-left: 4px solid #28a745; }
+        .active-alert .info {
+            flex: 1;
+            font-weight: bold;
+            color: #1a3f78;
+        }
+        .active-alert .fecha { font-size: 14px; color: #666; }
+        .active-alert .acciones { display: flex; gap: 6px; }
+        .active-alert .acciones form { display: inline; }
+        .btn-toggle {
+            background-color: #007bff;
+            color: white;
+            padding: 6px 12px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
         /* Estilos para la configuración de umbrales */
         .thresholds { display:flex; flex-wrap:wrap; gap:20px; margin-bottom:40px; }
         .threshold-card {

--- a/app/src/main/resources/templates/alertas.html
+++ b/app/src/main/resources/templates/alertas.html
@@ -65,15 +65,27 @@
             flex-direction: column;
             gap: 12px;
         }
-        .active-alerts h2 {
+        .active-alerts-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
             margin-bottom: 10px;
             color: #1a3f78;
         }
+        .alert-header,
         .active-alert {
-            display: flex;
+            display: grid;
+            grid-template-columns: 1fr 1fr auto;
             align-items: center;
             gap: 20px;
             padding: 12px 16px;
+        }
+        .alert-header {
+            font-weight: bold;
+            background-color: #f0f2f5;
+            border-radius: 6px;
+        }
+        .active-alert {
             border-radius: 6px;
             box-shadow: 0 2px 4px rgba(0,0,0,0.05);
             background-color: #ffffff;
@@ -82,7 +94,6 @@
         .active-alert.medium { border-left: 4px solid #ffc107; }
         .active-alert.low { border-left: 4px solid #28a745; }
         .active-alert .info {
-            flex: 1;
             font-weight: bold;
             color: #1a3f78;
         }
@@ -174,7 +185,17 @@
     </form>
 
     <div class="active-alerts" th:if="${alertasActivas != null}">
-        <h2>Alertas Activas (<span th:text="${alertasActivas.size()}"></span>)</h2>
+        <div class="active-alerts-header">
+            <h2>Alertas Activas (<span th:text="${alertasActivas.size()}"></span>)</h2>
+            <form th:action="@{/alertas/eliminar-todas}" method="post" onsubmit="return confirm('¿Eliminar todas las alertas?');">
+                <button type="submit" class="btn-delete">Eliminar todas las alertas</button>
+            </form>
+        </div>
+        <div class="alert-header">
+            <div>Medición</div>
+            <div>Fecha de actualización</div>
+            <div>Acciones</div>
+        </div>
         <div th:each="aa : ${alertasActivas}" th:classappend=" ${aa.alerta.prioridad.toLowerCase()}" class="active-alert">
             <div class="info" th:text="${aa.alerta.nombre + ': ' + #numbers.formatDecimal(aa.valorActual,1,1) + (aa.alerta.nombre == 'Temperatura' ? '°C' : aa.alerta.nombre == 'Humedad' ? '%' : aa.alerta.nombre == 'VelocidadViento' ? ' km/h' : ' mm') + ' (Umbral: ' + aa.alerta.umbral + (aa.alerta.nombre == 'Temperatura' ? '°C' : aa.alerta.nombre == 'Humedad' ? '%' : aa.alerta.nombre == 'VelocidadViento' ? ' km/h' : ' mm') + ')'}"></div>
             <div class="fecha" th:text="${#temporals.format(aa.fecha.toInstant(), 'dd/MM/yyyy HH:mm')}"></div>
@@ -187,10 +208,6 @@
                     <input type="hidden" name="prioridad" th:value="${aa.alerta.prioridad}" />
                     <input type="hidden" name="activa" th:value="${!aa.alerta.activa}" />
                     <button type="submit" class="btn-toggle" th:text="${aa.alerta.activa ? 'Desactivar' : 'Activar'}"></button>
-                </form>
-                <form th:action="@{/alertas/eliminar}" method="post" onsubmit="return confirm('¿Eliminar alerta?');">
-                    <input type="hidden" name="id" th:value="${aa.alerta.id}" />
-                    <button type="submit" class="btn-delete">Eliminar</button>
                 </form>
             </div>
         </div>

--- a/app/src/main/resources/templates/alertas.html
+++ b/app/src/main/resources/templates/alertas.html
@@ -100,25 +100,32 @@
         /* Estilos para la configuración de umbrales */
         .thresholds { display:flex; flex-wrap:wrap; gap:20px; margin-bottom:40px; }
         .threshold-card {
-            background:white;
-            border-radius:8px;
-            box-shadow:0 2px 4px rgba(0,0,0,0.1);
-            padding:20px;
-            width:200px;
-            text-align:center;
-            display:flex;
-            flex-direction:column;
-            align-items:center;
+            background: linear-gradient(135deg, #1e3a72 0%, #2d4a85 100%);
+            color: white;
+            border-radius: 10px;
+            padding: 20px;
+            width: 200px;
+            text-align: center;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
         }
-        .threshold-card label { font-weight:bold; margin-bottom:8px; }
+        .threshold-card:hover {
+            transform: translateY(-5px) scale(1.05);
+            box-shadow: 0 8px 16px rgba(0,0,0,0.3);
+        }
+        .threshold-card label { font-weight: bold; margin-bottom: 8px; color: white; }
         .threshold-card input {
-            padding:6px;
-            border:1px solid #ccc;
-            border-radius:4px;
-            text-align:center;
-            width:100%;
+            padding: 6px;
+            border: 1px solid rgba(255,255,255,0.7);
+            border-radius: 4px;
+            text-align: center;
+            width: 100%;
+            margin-bottom: 4px;
         }
-        .threshold-card span { margin-top:4px; color:#555; }
+        .threshold-card span { margin-top: 4px; color: white; }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add `AlertaActivaDTO` to carry active alert info
- extend `AlertasController` to build list of current active alerts and expose it to the view
- display active alerts on `alertas.html` with modern horizontal cards and actions

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686178e7fb18832298ca921f725ee513