### PR TITLE
Mejorar tarjetas de alertas activas

### DIFF
--- a/app/src/main/java/org/javadominicano/controladores/AlertasController.java
+++ b/app/src/main/java/org/javadominicano/controladores/AlertasController.java
@@ -81,6 +81,12 @@ public class AlertasController {
         return "redirect:/alertas";
     }
 
+    @PostMapping("/alertas/eliminar-todas")
+    public String eliminarTodasLasAlertas() {
+        repoAlerta.deleteAll();
+        return "redirect:/alertas";
+    }
+
     private List<AlertaActivaDTO> obtenerAlertasActivas() {
         List<AlertaActivaDTO> lista = new ArrayList<>();
 

--- a/app/src/main/resources/templates/alertas.html
+++ b/app/src/main/resources/templates/alertas.html
@@ -63,14 +63,30 @@
             margin-bottom: 40px;
             display: flex;
             flex-direction: column;
-            gap: 12px;
+            gap: 16px;
         }
-        .active-alerts h2 {
+        .active-alerts-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
             margin-bottom: 10px;
+        }
+        .active-alerts-header h2 {
+            font-size: 20px;
+            font-weight: bold;
             color: #1a3f78;
+        }
+        .btn-delete-all {
+            background-color: #dc3545;
+            color: white;
+            padding: 6px 12px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
         }
         .active-alert {
             display: flex;
+            justify-content: space-between;
             align-items: center;
             gap: 20px;
             padding: 12px 16px;
@@ -81,13 +97,20 @@
         .active-alert.high { border-left: 4px solid #dc3545; }
         .active-alert.medium { border-left: 4px solid #ffc107; }
         .active-alert.low { border-left: 4px solid #28a745; }
-        .active-alert .info {
+        .alert-details {
             flex: 1;
+            display: flex;
+            flex-direction: column;
+        }
+        .alert-details .info {
             font-weight: bold;
             color: #1a3f78;
         }
-        .active-alert .fecha { font-size: 14px; color: #666; }
-        .active-alert .acciones { display: flex; gap: 6px; }
+        .alert-details .fecha {
+            font-size: 14px;
+            color: #666;
+            margin-top: 4px;
+        }
         .active-alert .acciones form { display: inline; }
         .btn-toggle {
             background-color: #007bff;
@@ -174,25 +197,26 @@
     </form>
 
     <div class="active-alerts" th:if="${alertasActivas != null}">
-        <h2>Alertas Activas (<span th:text="${alertasActivas.size()}"></span>)</h2>
+        <div class="active-alerts-header">
+            <h2>Alertas Activas (<span th:text="${alertasActivas.size()}"></span>)</h2>
+            <form th:action="@{/alertas/eliminar-todas}" method="post">
+                <button type="submit" class="btn-delete-all">Eliminar todas</button>
+            </form>
+        </div>
         <div th:each="aa : ${alertasActivas}" th:classappend=" ${aa.alerta.prioridad.toLowerCase()}" class="active-alert">
-            <div class="info" th:text="${aa.alerta.nombre + ': ' + #numbers.formatDecimal(aa.valorActual,1,1) + (aa.alerta.nombre == 'Temperatura' ? '°C' : aa.alerta.nombre == 'Humedad' ? '%' : aa.alerta.nombre == 'VelocidadViento' ? ' km/h' : ' mm') + ' (Umbral: ' + aa.alerta.umbral + (aa.alerta.nombre == 'Temperatura' ? '°C' : aa.alerta.nombre == 'Humedad' ? '%' : aa.alerta.nombre == 'VelocidadViento' ? ' km/h' : ' mm') + ')'}"></div>
-            <div class="fecha" th:text="${#temporals.format(aa.fecha.toInstant(), 'dd/MM/yyyy HH:mm')}"></div>
-            <div class="acciones">
-                <form th:action="@{/alertas/guardar}" method="post">
-                    <input type="hidden" name="id" th:value="${aa.alerta.id}" />
-                    <input type="hidden" name="nombre" th:value="${aa.alerta.nombre}" />
-                    <input type="hidden" name="operador" th:value="${aa.alerta.operador}" />
-                    <input type="hidden" name="umbral" th:value="${aa.alerta.umbral}" />
-                    <input type="hidden" name="prioridad" th:value="${aa.alerta.prioridad}" />
-                    <input type="hidden" name="activa" th:value="${!aa.alerta.activa}" />
-                    <button type="submit" class="btn-toggle" th:text="${aa.alerta.activa ? 'Desactivar' : 'Activar'}"></button>
-                </form>
-                <form th:action="@{/alertas/eliminar}" method="post" onsubmit="return confirm('¿Eliminar alerta?');">
-                    <input type="hidden" name="id" th:value="${aa.alerta.id}" />
-                    <button type="submit" class="btn-delete">Eliminar</button>
-                </form>
+            <div class="alert-details">
+                <div class="info" th:text="${aa.alerta.nombre + ': ' + #numbers.formatDecimal(aa.valorActual,1,1) + (aa.alerta.nombre == 'Temperatura' ? '°C' : aa.alerta.nombre == 'Humedad' ? '%' : aa.alerta.nombre == 'VelocidadViento' ? ' km/h' : ' mm') + ' (Umbral: ' + aa.alerta.umbral + (aa.alerta.nombre == 'Temperatura' ? '°C' : aa.alerta.nombre == 'Humedad' ? '%' : aa.alerta.nombre == 'VelocidadViento' ? ' km/h' : ' mm') + ')'}"></div>
+                <div class="fecha" th:text="${#temporals.format(aa.fecha.toInstant(), 'dd/MM/yyyy HH:mm')}"></div>
             </div>
+            <form class="acciones" th:action="@{/alertas/guardar}" method="post">
+                <input type="hidden" name="id" th:value="${aa.alerta.id}" />
+                <input type="hidden" name="nombre" th:value="${aa.alerta.nombre}" />
+                <input type="hidden" name="operador" th:value="${aa.alerta.operador}" />
+                <input type="hidden" name="umbral" th:value="${aa.alerta.umbral}" />
+                <input type="hidden" name="prioridad" th:value="${aa.alerta.prioridad}" />
+                <input type="hidden" name="activa" th:value="${!aa.alerta.activa}" />
+                <button type="submit" class="btn-toggle">Desactivar</button>
+            </form>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- ajustar estilo para la lista de alertas activas
- crear cabecera con contador y boton "Eliminar todas"
- reorganizar tarjetas de alerta con detalles y boton de desactivacion
- agregar endpoint para eliminar todas las alertas

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6861825efdec83228e68cc6b157845a5