### PR TITLE
Uniform alert messages and global display

### DIFF
--- a/app/src/main/java/org/javadominicano/configuracion/GlobalAlertasAdvice.java
+++ b/app/src/main/java/org/javadominicano/configuracion/GlobalAlertasAdvice.java
@@ -1,0 +1,20 @@
+package org.javadominicano.configuracion;
+
+import org.javadominicano.servicio.ServicioAlertas;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+import java.util.List;
+
+@ControllerAdvice
+public class GlobalAlertasAdvice {
+
+    @Autowired
+    private ServicioAlertas servicioAlertas;
+
+    @ModelAttribute("alertasActivas")
+    public List<String> alertasActivas() {
+        return servicioAlertas.obtenerAlertasActivasDescripcion();
+    }
+}

--- a/app/src/main/java/org/javadominicano/controladores/VisualizadorController.java
+++ b/app/src/main/java/org/javadominicano/controladores/VisualizadorController.java
@@ -10,6 +10,7 @@ import org.javadominicano.visualizadorweb.entidades.Umbrales;
 import org.javadominicano.entidades.Alerta;
 import org.javadominicano.entidades.EstacionMeteorologica;
 import org.javadominicano.repositorios.RepositorioEstacionMeteorologica;
+import org.javadominicano.servicio.ServicioAlertas;
 
 import org.javadominicano.repositorios.RepositorioDatosDireccion;
 import org.javadominicano.repositorios.RepositorioDatosPrecipitacion;
@@ -57,6 +58,9 @@ public class VisualizadorController {
 
     @Autowired
     private RepositorioAlerta repoAlerta;
+
+    @Autowired
+    private ServicioAlertas servicioAlertas;
 
     // Inyecta el objeto umbrales para Thymeleaf con valores por defecto
     @ModelAttribute("umbrales")
@@ -217,7 +221,7 @@ public class VisualizadorController {
     }
 
     private String formatoAlerta(Alerta a) {
-        return a.getNombre() + " " + a.getOperador() + " " + a.getUmbral();
+        return servicioAlertas.descripcion(a);
     }
 
     // Eliminar estación

--- a/app/src/main/java/org/javadominicano/controladores/VisualizadorController.java
+++ b/app/src/main/java/org/javadominicano/controladores/VisualizadorController.java
@@ -10,7 +10,6 @@ import org.javadominicano.visualizadorweb.entidades.Umbrales;
 import org.javadominicano.entidades.Alerta;
 import org.javadominicano.entidades.EstacionMeteorologica;
 import org.javadominicano.repositorios.RepositorioEstacionMeteorologica;
-import org.javadominicano.servicio.ServicioAlertas;
 
 import org.javadominicano.repositorios.RepositorioDatosDireccion;
 import org.javadominicano.repositorios.RepositorioDatosPrecipitacion;
@@ -58,9 +57,6 @@ public class VisualizadorController {
 
     @Autowired
     private RepositorioAlerta repoAlerta;
-
-    @Autowired
-    private ServicioAlertas servicioAlertas;
 
     // Inyecta el objeto umbrales para Thymeleaf con valores por defecto
     @ModelAttribute("umbrales")
@@ -149,23 +145,6 @@ public class VisualizadorController {
             }
         }
 
-        List<String> alertasActivas = new ArrayList<>();
-        Alerta alTemp = repoAlerta.findByNombre("Temperatura");
-        if (chequearAlerta(alTemp, mediciones.getTemperatura())) {
-            alertasActivas.add(formatoAlerta(alTemp));
-        }
-        Alerta alHum = repoAlerta.findByNombre("Humedad");
-        if (chequearAlerta(alHum, mediciones.getHumedad())) {
-            alertasActivas.add(formatoAlerta(alHum));
-        }
-        Alerta alVel = repoAlerta.findByNombre("VelocidadViento");
-        if (chequearAlerta(alVel, mediciones.getVelocidadViento())) {
-            alertasActivas.add(formatoAlerta(alVel));
-        }
-        Alerta alPre = repoAlerta.findByNombre("Precipitacion");
-        if (chequearAlerta(alPre, mediciones.getPrecipitacion())) {
-            alertasActivas.add(formatoAlerta(alPre));
-        }
 
         model.addAttribute("velocidades", velocidades);
         model.addAttribute("direcciones", direcciones);
@@ -175,7 +154,6 @@ public class VisualizadorController {
         model.addAttribute("mediciones", mediciones);
         model.addAttribute("paginaActual", pagina);
         model.addAttribute("tamanoPagina", tamanoPagina);
-        model.addAttribute("alertasActivas", alertasActivas);
 
         // Nuevos atributos para la vista
         model.addAttribute("estacionesActivas", estacionesActivas);
@@ -209,20 +187,6 @@ public class VisualizadorController {
         repoAlerta.save(a);
     }
 
-    private boolean chequearAlerta(Alerta alerta, Double valor) {
-        if (alerta == null || valor == null || !alerta.isActiva()) {
-            return false;
-        }
-        if (">".equals(alerta.getOperador())) {
-            return valor > alerta.getUmbral();
-        } else {
-            return valor < alerta.getUmbral();
-        }
-    }
-
-    private String formatoAlerta(Alerta a) {
-        return servicioAlertas.descripcion(a);
-    }
 
     // Eliminar estación
     @PostMapping("/estaciones/eliminar")

--- a/app/src/main/java/org/javadominicano/servicio/ServicioAlertas.java
+++ b/app/src/main/java/org/javadominicano/servicio/ServicioAlertas.java
@@ -1,0 +1,81 @@
+package org.javadominicano.servicio;
+
+import org.javadominicano.entidades.Alerta;
+import org.javadominicano.entidades.DatosPrecipitacion;
+import org.javadominicano.entidades.DatosVelocidad;
+import org.javadominicano.visualizadorweb.entidades.DatosHumedad;
+import org.javadominicano.visualizadorweb.entidades.DatosTemperatura;
+import org.javadominicano.repositorios.RepositorioAlerta;
+import org.javadominicano.repositorios.RepositorioDatosPrecipitacion;
+import org.javadominicano.repositorios.RepositorioDatosVelocidad;
+import org.javadominicano.visualizadorweb.repositorios.RepositorioDatosHumedad;
+import org.javadominicano.visualizadorweb.repositorios.RepositorioDatosTemperatura;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class ServicioAlertas {
+
+    @Autowired
+    private RepositorioAlerta repoAlerta;
+
+    @Autowired
+    private RepositorioDatosVelocidad repoVelocidad;
+
+    @Autowired
+    private RepositorioDatosHumedad repoHumedad;
+
+    @Autowired
+    private RepositorioDatosTemperatura repoTemperatura;
+
+    @Autowired
+    private RepositorioDatosPrecipitacion repoPrecipitacion;
+
+    public List<String> obtenerAlertasActivasDescripcion() {
+        List<String> lista = new ArrayList<>();
+
+        DatosTemperatura temp = repoTemperatura.findTopByOrderByFechaDesc(PageRequest.of(0, 1)).get(0);
+        DatosHumedad hum = repoHumedad.findTopByOrderByFechaDesc(PageRequest.of(0, 1)).get(0);
+        DatosVelocidad vel = repoVelocidad.findTopByOrderByFechaDesc(PageRequest.of(0, 1)).get(0);
+        DatosPrecipitacion pre = repoPrecipitacion.findTopByOrderByFechaDesc(PageRequest.of(0, 1)).get(0);
+
+        agregarAlerta(lista, repoAlerta.findByNombre("Temperatura"), temp.getTemperatura());
+        agregarAlerta(lista, repoAlerta.findByNombre("Humedad"), hum.getHumedad());
+        agregarAlerta(lista, repoAlerta.findByNombre("VelocidadViento"), vel.getVelocidad());
+        agregarAlerta(lista, repoAlerta.findByNombre("Precipitacion"), pre.getProbabilidad());
+
+        return lista;
+    }
+
+    private void agregarAlerta(List<String> lista, Alerta alerta, Double valor) {
+        if (chequearAlerta(alerta, valor)) {
+            lista.add(descripcion(alerta));
+        }
+    }
+
+    private boolean chequearAlerta(Alerta alerta, Double valor) {
+        if (alerta == null || valor == null || !alerta.isActiva()) {
+            return false;
+        }
+        if (">".equals(alerta.getOperador())) {
+            return valor > alerta.getUmbral();
+        } else {
+            return valor < alerta.getUmbral();
+        }
+    }
+
+    public String descripcion(Alerta alerta) {
+        if (alerta == null) return "";
+        return switch (alerta.getNombre()) {
+            case "Temperatura" -> "Umbral de temperatura superado";
+            case "Humedad" -> "Umbral de humedad superado";
+            case "VelocidadViento" -> "Umbral de velocidad de viento superado";
+            case "Precipitacion" -> "Umbral de precipitación superado";
+            default -> "Alerta activa";
+        };
+    }
+}

--- a/app/src/main/resources/templates/alertas.html
+++ b/app/src/main/resources/templates/alertas.html
@@ -205,6 +205,7 @@
     </form>
 </div>
 <div class="content">
+    <div th:replace="fragments/alertasActivas :: alerts"></div>
     <h1 style="margin-bottom:20px;">Configuración de Alertas</h1>
     <form class="thresholds" method="post" th:action="@{/configurar-alertas}">
         <div class="threshold-card">
@@ -260,7 +261,7 @@
         </div>
         <div th:each="a : ${alertas}" th:classappend=" ${a.prioridad.toLowerCase()}" class="configured-alert">
             <div class="alert-details">
-                <div class="info" th:text="${a.nombre + ' - ' + (a.operador == '>' ? 'Mayor que ' : 'Menor que ') + a.umbral + (a.nombre == 'Temperatura' ? '°C' : a.nombre == 'Humedad' ? '%' : a.nombre == 'VelocidadViento' ? ' km/h' : ' mm')}"></div>
+                <div class="info" th:text="${a.nombre == 'Temperatura' ? 'Umbral de temperatura superado' : a.nombre == 'Humedad' ? 'Umbral de humedad superado' : a.nombre == 'VelocidadViento' ? 'Umbral de velocidad de viento superado' : 'Umbral de precipitación superado'}"></div>
                 <div class="fecha" th:text="${#temporals.format(a.fechaCreacion.toInstant(), 'dd/MM/yyyy HH:mm')}"></div>
             </div>
             <form class="acciones" th:action="@{/alertas/guardar}" method="post">

--- a/app/src/main/resources/templates/dashboard.html
+++ b/app/src/main/resources/templates/dashboard.html
@@ -497,12 +497,7 @@
         </form>
     </div>
 
-    <div th:if="${alertasActivas != null}" id="alertContainer">
-        <div th:each="a : ${alertasActivas}" class="alert-card">
-            <span th:text="${a}">Alerta</span>
-            <button type="button" class="close-alert">&times;</button>
-        </div>
-    </div>
+    <div th:replace="fragments/alertasActivas :: alerts"></div>
 
     <div class="cards">
         <div class="card">

--- a/app/src/main/resources/templates/editarEstacion.html
+++ b/app/src/main/resources/templates/editarEstacion.html
@@ -127,6 +127,7 @@
     </style>
 </head>
 <body>
+<div th:replace="fragments/alertasActivas :: alerts"></div>
 <div class="form-container">
     <div class="station-icon">
         <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="white" class="bi bi-geo-alt" viewBox="0 0 16 16">

--- a/app/src/main/resources/templates/estaciones.html
+++ b/app/src/main/resources/templates/estaciones.html
@@ -163,6 +163,7 @@
 </div>
 
 <div class="content">
+    <div th:replace="fragments/alertasActivas :: alerts"></div>
     <div class="estaciones-container">
         <div class="estaciones-header">
             <div>

--- a/app/src/main/resources/templates/form-estacion.html
+++ b/app/src/main/resources/templates/form-estacion.html
@@ -126,6 +126,7 @@
     </style>
 </head>
 <body>
+<div th:replace="fragments/alertasActivas :: alerts"></div>
 <div class="form-container">
     <div class="station-icon">
         <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="white" class="bi bi-geo-alt" viewBox="0 0 16 16">

--- a/app/src/main/resources/templates/fragments/alertasActivas.html
+++ b/app/src/main/resources/templates/fragments/alertasActivas.html
@@ -1,0 +1,40 @@
+<div th:fragment="alerts">
+    <style>
+        .global-alerts {
+            margin-bottom: 15px;
+        }
+        .global-alerts .alert-card {
+            background-color: #dc3545;
+            color: white;
+            padding: 10px 15px;
+            border-radius: 5px;
+            margin-bottom: 10px;
+            position: relative;
+        }
+        .global-alerts .alert-card button {
+            position: absolute;
+            top: 5px;
+            right: 5px;
+            background: none;
+            border: none;
+            color: white;
+            font-size: 16px;
+            cursor: pointer;
+        }
+    </style>
+    <div th:if="${alertasActivas != null && !alertasActivas.isEmpty()}" class="global-alerts" id="globalAlertContainer">
+        <div th:each="a : ${alertasActivas}" class="alert-card">
+            <span th:text="${a}">Alerta</span>
+            <button type="button" class="close-alert">&times;</button>
+        </div>
+    </div>
+    <script th:inline="javascript">
+        document.querySelectorAll('.alert-card').forEach(card => {
+            const btn = card.querySelector('.close-alert');
+            if (btn) {
+                btn.addEventListener('click', () => card.remove());
+            }
+            setTimeout(() => card.remove(), 7000);
+        });
+    </script>
+</div>

--- a/app/src/main/resources/templates/reportePreview.html
+++ b/app/src/main/resources/templates/reportePreview.html
@@ -47,6 +47,7 @@
         </form>
     </div>
     <div class="content">
+        <div th:replace="fragments/alertasActivas :: alerts"></div>
         <h1 th:text="${reporte.titulo}"></h1>
         <p th:text="${reporte.estacion}"></p>
         <div class="tablas">

--- a/app/src/main/resources/templates/reportes.html
+++ b/app/src/main/resources/templates/reportes.html
@@ -99,6 +99,7 @@
     </div>
 
     <div class="content">
+        <div th:replace="fragments/alertasActivas :: alerts"></div>
         <h1>Reportes</h1>
         <p class="subtitle">Generación de reportes y análisis</p>
 

--- a/app/src/main/resources/templates/tablas.html
+++ b/app/src/main/resources/templates/tablas.html
@@ -57,6 +57,7 @@
   </div>
 
   <div class="content">
+    <div th:replace="fragments/alertasActivas :: alerts"></div>
     <h1>Tablas de la Base de Datos</h1>
 
     <div class="tablas">


### PR DESCRIPTION
## Summary
- inject active alerts across controllers
- centralize alert logic in `ServicioAlertas`
- display active alerts on all pages via a Thymeleaf fragment
- simplify dashboard and add the fragment to templates
- show clearer description for configured alerts

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6861951e1d8c8322a846f54a2c533dec