### PR TITLE
Mostrar alertas activas en todas las vistas

### DIFF
--- a/app/src/main/resources/templates/fragments/alertasActivas.html
+++ b/app/src/main/resources/templates/fragments/alertasActivas.html
@@ -36,14 +36,15 @@
             card.remove();
             return;
         }
-        localStorage.setItem(key, 'shown');
         var btn = card.querySelector('.close-alert');
+        var markAsShown = function() {
+            localStorage.setItem(key, 'shown');
+            card.remove();
+        };
         if (btn) {
-            btn.addEventListener('click', function() {
-                card.remove();
-            });
+            btn.addEventListener('click', markAsShown);
         }
-        setTimeout(function() { card.remove(); }, 7000);
+        setTimeout(markAsShown, 7000);
     });
     /*]]>*/
     </script>


### PR DESCRIPTION
## Summary
- ensure the active alerts banner works across pages
- keep expiration logic by saving the key when closing or after timeout

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861a6dbfe488322b3f1eb5d239421c5