### PR TITLE
Fix alerts pending count and add clear reports button

### DIFF
--- a/app/src/main/java/org/javadominicano/controladores/AlertasController.java
+++ b/app/src/main/java/org/javadominicano/controladores/AlertasController.java
@@ -69,7 +69,10 @@ public class AlertasController {
 
         List<AlertaActivaDTO> activas = alertasService.obtenerAlertasActivas();
         model.addAttribute("alertasActivas", activas);
-        model.addAttribute("alertasPendientes", repoAlerta.countByActiva(false));
+
+        long configuradasActivas = repoAlerta.countByActiva(true);
+        long pendientes = configuradasActivas - activas.size();
+        model.addAttribute("alertasPendientes", pendientes < 0 ? 0 : pendientes);
 
         return "alertas";
     }
@@ -91,7 +94,9 @@ public class AlertasController {
         model.addAttribute("alertas", repoAlerta.findAll());
         model.addAttribute("nuevaAlerta", new Alerta());
         model.addAttribute("alertasActivas", new ArrayList<AlertaActivaDTO>());
-        model.addAttribute("alertasPendientes", repoAlerta.countByActiva(false));
+
+        long configuradasActivas = repoAlerta.countByActiva(true);
+        model.addAttribute("alertasPendientes", configuradasActivas);
         return "alertas";
     }
 

--- a/app/src/main/java/org/javadominicano/controladores/ReportesController.java
+++ b/app/src/main/java/org/javadominicano/controladores/ReportesController.java
@@ -75,6 +75,12 @@ public class ReportesController {
         return "redirect:/reportes?fecha=" + fecha + "&estacion=" + estacion + "&tipo=" + tipo;
     }
 
+    @PostMapping("/reportes/limpiar")
+    public String limpiarHistorial() {
+        reportesGenerados.clear();
+        return "redirect:/reportes";
+    }
+
     @GetMapping("/reportes")
     public String mostrarReportes(
             @RequestParam(value = "fecha", required = false)

--- a/app/src/main/resources/templates/reportes.html
+++ b/app/src/main/resources/templates/reportes.html
@@ -62,7 +62,8 @@
         }
         .report-generator .full-width {
             grid-column: span 2;
-            text-align: right;
+            display: flex;
+            justify-content: space-between;
         }
 
         .recent-reports { margin-top: 10px; }
@@ -132,6 +133,7 @@
                 </div>
 
                 <div class="full-width">
+                    <button type="submit" th:formaction="@{/reportes/limpiar}" formmethod="post">Limpiar Historial</button>
                     <button type="submit">Generar Reporte</button>
                 </div>
             </form>


### PR DESCRIPTION
## Summary
- correct the calculation of pending alerts
- add endpoint to clear generated reports and expose a button in the report view
- adjust button layout in the report generator

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861e71d57e08322bfcffa94d36f8896