### PR TITLE
Rename precipitation display to pressure

### DIFF
--- a/app/src/main/java/org/javadominicano/controladores/ReportesController.java
+++ b/app/src/main/java/org/javadominicano/controladores/ReportesController.java
@@ -53,9 +53,16 @@ public class ReportesController {
 
     @PostMapping("/reportes")
     public String generarReporte(
-            @RequestParam("fecha") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fecha,
+            @RequestParam(value = "fecha", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fecha,
             @RequestParam("estacion") String estacion,
-            @RequestParam("tipo") String tipo) {
+            @RequestParam("tipo") String tipo,
+            Model model) {
+
+        if (fecha == null) {
+            model.addAttribute("errorFecha", "Debe seleccionar una fecha para generar el reporte");
+            return mostrarReportes(null, estacion, tipo, 0, 10, model);
+        }
 
         String titulo = "";
         if ("diario".equals(tipo)) {

--- a/app/src/main/java/org/servicios/AlertasService.java
+++ b/app/src/main/java/org/servicios/AlertasService.java
@@ -90,7 +90,7 @@ public class AlertasService {
             case "VelocidadViento":
                 return "Umbral de velocidad de viento superado";
             case "Precipitacion":
-                return "Umbral de precipitación superado";
+                return "Umbral de presión superado";
             default:
                 return "Umbral superado";
         }

--- a/app/src/main/resources/templates/alertas.html
+++ b/app/src/main/resources/templates/alertas.html
@@ -266,7 +266,7 @@
         </div>
         <div th:each="aa : ${alertasActivas}" th:classappend=" ${aa.alerta.prioridad.toLowerCase()}" class="active-alert">
             <div class="alert-details">
-                <div class="info" th:text="${aa.alerta.nombre + ': ' + #numbers.formatDecimal(aa.valorActual,1,1) + (aa.alerta.nombre == 'Temperatura' ? '°C' : aa.alerta.nombre == 'Humedad' ? '%' : aa.alerta.nombre == 'VelocidadViento' ? ' km/h' : ' hPa') + ' (Umbral: ' + aa.alerta.umbral + (aa.alerta.nombre == 'Temperatura' ? '°C' : aa.alerta.nombre == 'Humedad' ? '%' : aa.alerta.nombre == 'VelocidadViento' ? ' km/h' : ' hPa') + ')'}"></div>
+                <div class="info" th:text="${(aa.alerta.nombre == 'Precipitacion' ? 'Presión' : aa.alerta.nombre) + ': ' + #numbers.formatDecimal(aa.valorActual,1,1) + (aa.alerta.nombre == 'Temperatura' ? '°C' : aa.alerta.nombre == 'Humedad' ? '%' : aa.alerta.nombre == 'VelocidadViento' ? ' km/h' : ' hPa') + ' (Umbral: ' + aa.alerta.umbral + (aa.alerta.nombre == 'Temperatura' ? '°C' : aa.alerta.nombre == 'Humedad' ? '%' : aa.alerta.nombre == 'VelocidadViento' ? ' km/h' : ' hPa') + ')'}"></div>
                 <div class="fecha" th:text="${#temporals.format(aa.fecha.toInstant(), 'dd/MM/yyyy HH:mm')}"></div>
             </div>
             <form class="acciones" th:action="@{/alertas/guardar}" method="post">

--- a/app/src/main/resources/templates/alertas.html
+++ b/app/src/main/resources/templates/alertas.html
@@ -249,10 +249,10 @@
         <div class="threshold-card">
             <div class="title-row">
                 <input type="checkbox" id="chk-pre" name="chkPre" checked />
-                <label for="pre">Precipitación &gt;</label>
+                <label for="pre">Presión &gt;</label>
             </div>
             <input id="pre" type="number" step="0.1" name="precipitacion" th:value="${umbrales.precipitacion}" required />
-            <span>mm</span>
+            <span>hPa</span>
         </div>
         <button type="submit" class="btn btn-edit" style="align-self:flex-start;">Guardar</button>
     </form>
@@ -266,7 +266,7 @@
         </div>
         <div th:each="aa : ${alertasActivas}" th:classappend=" ${aa.alerta.prioridad.toLowerCase()}" class="active-alert">
             <div class="alert-details">
-                <div class="info" th:text="${aa.alerta.nombre + ': ' + #numbers.formatDecimal(aa.valorActual,1,1) + (aa.alerta.nombre == 'Temperatura' ? '°C' : aa.alerta.nombre == 'Humedad' ? '%' : aa.alerta.nombre == 'VelocidadViento' ? ' km/h' : ' mm') + ' (Umbral: ' + aa.alerta.umbral + (aa.alerta.nombre == 'Temperatura' ? '°C' : aa.alerta.nombre == 'Humedad' ? '%' : aa.alerta.nombre == 'VelocidadViento' ? ' km/h' : ' mm') + ')'}"></div>
+                <div class="info" th:text="${aa.alerta.nombre + ': ' + #numbers.formatDecimal(aa.valorActual,1,1) + (aa.alerta.nombre == 'Temperatura' ? '°C' : aa.alerta.nombre == 'Humedad' ? '%' : aa.alerta.nombre == 'VelocidadViento' ? ' km/h' : ' hPa') + ' (Umbral: ' + aa.alerta.umbral + (aa.alerta.nombre == 'Temperatura' ? '°C' : aa.alerta.nombre == 'Humedad' ? '%' : aa.alerta.nombre == 'VelocidadViento' ? ' km/h' : ' hPa') + ')'}"></div>
                 <div class="fecha" th:text="${#temporals.format(aa.fecha.toInstant(), 'dd/MM/yyyy HH:mm')}"></div>
             </div>
             <form class="acciones" th:action="@{/alertas/guardar}" method="post">
@@ -294,7 +294,7 @@
                      th:text="${a.nombre == 'Temperatura' ? 'Temperatura ' + a.operador + ' ' + #numbers.formatDecimal(a.umbral,1,1) + ' °C' :
                                  a.nombre == 'Humedad' ? 'Humedad ' + a.operador + ' ' + #numbers.formatDecimal(a.umbral,1,1) + ' %' :
                                  a.nombre == 'VelocidadViento' ? 'Velocidad del viento ' + a.operador + ' ' + #numbers.formatDecimal(a.umbral,1,1) + ' km/h' :
-                                 'Precipitación ' + a.operador + ' ' + #numbers.formatDecimal(a.umbral,1,1) + ' mm'}"></div>
+                                 'Presión ' + a.operador + ' ' + #numbers.formatDecimal(a.umbral,1,1) + ' hPa'}"></div>
                 <div class="fecha" th:text="${#temporals.format(a.fechaCreacion.toInstant(), 'dd/MM/yyyy HH:mm')}"></div>
             </div>
             <form class="acciones" th:action="@{/alertas/guardar}" method="post">

--- a/app/src/main/resources/templates/dashboard.html
+++ b/app/src/main/resources/templates/dashboard.html
@@ -401,8 +401,8 @@
                 <path d="M12 16v3" />
                 <path d="M16 16v3" />
             </svg>
-            <p th:text="${#numbers.formatDecimal(mediciones.precipitacion, 1, 1) + 'mm'}">75.6mm</p>
-            <span>Precipitación</span>
+            <p th:text="${#numbers.formatDecimal(mediciones.precipitacion, 1, 1) + ' hPa'}">75.6 hPa</p>
+            <span>Presión</span>
         </div>
     </div>
 

--- a/app/src/main/resources/templates/fragments/alertasActivas.html
+++ b/app/src/main/resources/templates/fragments/alertasActivas.html
@@ -26,7 +26,7 @@
             <span th:text="${a.alerta.nombre == 'Temperatura' ? 'Umbral de temperatura superado' :
                              a.alerta.nombre == 'Humedad' ? 'Umbral de humedad superado' :
                              a.alerta.nombre == 'VelocidadViento' ? 'Umbral de velocidad de viento superado' :
-                             'Umbral de precipitación superado'}">Alerta</span>
+                             'Umbral de presión superado'}">Alerta</span>
             <button type="button" class="close-alert">&times;</button>
         </div>
     </div>

--- a/app/src/main/resources/templates/reportePreview.html
+++ b/app/src/main/resources/templates/reportePreview.html
@@ -78,9 +78,9 @@
                 </table>
             </div>
             <div class="tabla">
-                <h3>Precipitación</h3>
+                <h3>Presión</h3>
                 <table>
-                    <thead><tr><th>ID</th><th>mm</th><th>Fecha</th></tr></thead>
+                    <thead><tr><th>ID</th><th>hPa</th><th>Fecha</th></tr></thead>
                     <tbody>
                         <tr th:each="p : ${precipitaciones}">
                             <td th:text="${p.id}"></td>

--- a/app/src/main/resources/templates/reportes.html
+++ b/app/src/main/resources/templates/reportes.html
@@ -66,6 +66,12 @@
             justify-content: space-between;
         }
 
+        .report-generator .error {
+            color: red;
+            grid-column: span 2;
+            font-size: 14px;
+        }
+
         .recent-reports { margin-top: 10px; }
         .recent-reports h2 { color: #1a3f78; margin-bottom: 10px; }
         .report-item { background: white; border-radius: 6px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); padding: 10px 15px; display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; }
@@ -110,6 +116,7 @@
                     <label for="fecha">Fecha:</label>
                     <input type="date" id="fecha" name="fecha" th:value="${fecha}" />
                 </div>
+                <div th:if="${errorFecha}" class="error" th:text="${errorFecha}"></div>
 
                 <div class="field">
                     <label for="estacion">Estación:</label>

--- a/app/src/main/resources/templates/tablas.html
+++ b/app/src/main/resources/templates/tablas.html
@@ -93,11 +93,11 @@
         </table>
       </div>
 
-      <!-- Precipitación -->
+      <!-- Presión -->
       <div class="tabla">
-        <h3>Precipitación</h3>
+        <h3>Presión</h3>
         <table>
-          <thead><tr><th>ID</th><th>Estación ID</th><th>mm</th><th>Fecha</th></tr></thead>
+          <thead><tr><th>ID</th><th>Estación ID</th><th>hPa</th><th>Fecha</th></tr></thead>
           <tbody>
             <tr th:each="p : ${precipitaciones.content}">
               <td th:text="${p.id}"></td>


### PR DESCRIPTION
## Summary
- update dashboard card to show "Presión" in hPa
- update tables and report preview to use "Presión" / "hPa"
- adjust alert labels and messages to refer to "Presión" and show hPa

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68669649e7708322942178229630b711