### PR TITLE
Enable realtime dashboard updates via WebSocket

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     // Seguridad
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.security:spring-security-crypto'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
     // Testing
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/app/src/main/java/org/javadominicano/EstacionWebApplication.java
+++ b/app/src/main/java/org/javadominicano/EstacionWebApplication.java
@@ -3,12 +3,14 @@ package org.javadominicano;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @ComponentScan(basePackages = {
     "org.javadominicano",              // Controladores, entidades, repositorios
     "com.javadominicano.configuracion" // SeguridadConfig
 })
+@EnableScheduling
 public class EstacionWebApplication {
     public static void main(String[] args) {
         SpringApplication.run(EstacionWebApplication.class, args);

--- a/app/src/main/java/org/javadominicano/configuracion/WebSocketConfig.java
+++ b/app/src/main/java/org/javadominicano/configuracion/WebSocketConfig.java
@@ -1,0 +1,22 @@
+package com.javadominicano.configuracion;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws").withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+}

--- a/app/src/main/java/org/javadominicano/controladores/DatosMeteorologicosController.java
+++ b/app/src/main/java/org/javadominicano/controladores/DatosMeteorologicosController.java
@@ -5,66 +5,16 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import org.javadominicano.dto.DatosMeteorologicosDTO;
-import org.javadominicano.dto.DatosMeteorologicosDTO.SerieDatos;
-
-import org.javadominicano.entidades.DatosVelocidad;
-import org.javadominicano.visualizadorweb.entidades.DatosHumedad;
-import org.javadominicano.visualizadorweb.entidades.DatosTemperatura;
-
-import org.javadominicano.repositorios.DatosVelocidadRepository;
-import org.javadominicano.visualizadorweb.repositorios.DatosHumedadRepository;
-import org.javadominicano.visualizadorweb.repositorios.DatosTemperaturaRepository;
-
-import java.time.format.DateTimeFormatter;
-import java.util.*;
-import java.util.stream.Collectors;
+import org.javadominicano.servicios.DashboardDataService;
 
 @RestController
 public class DatosMeteorologicosController {
 
     @Autowired
-    private DatosVelocidadRepository repoVelocidad;
-
-    @Autowired
-    private DatosHumedadRepository repoHumedad;
-
-    @Autowired
-    private DatosTemperaturaRepository repoTemperatura;
-
-    private DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+    private DashboardDataService dashboardDataService;
 
     @GetMapping("/api/datos-meteorologicos")
     public DatosMeteorologicosDTO obtenerDatos() {
-        List<DatosVelocidad> velocidades = repoVelocidad.findTop30ByOrderByFechaDesc();
-        List<DatosHumedad> humedades = repoHumedad.findTop30ByOrderByFechaDesc();
-        List<DatosTemperatura> temperaturas = repoTemperatura.findTop30ByOrderByFechaDesc();
-
-        // Ordenar ascendente (más antiguo a más reciente)
-        velocidades.sort(Comparator.comparing(DatosVelocidad::getFecha));
-        humedades.sort(Comparator.comparing(DatosHumedad::getFecha));
-        temperaturas.sort(Comparator.comparing(DatosTemperatura::getFecha));
-
-        // Construir listas para labels y valores (suponemos que fechas coinciden o tomamos la de velocidad)
-        List<String> labels = velocidades.stream()
-            .map(d -> d.getFecha().toLocalDateTime().format(formatter))
-            .collect(Collectors.toList());
-
-        List<Double> windValues = velocidades.stream()
-            .map(DatosVelocidad::getVelocidad)
-            .collect(Collectors.toList());
-
-        List<Double> humidityValues = humedades.stream()
-            .map(DatosHumedad::getHumedad)
-            .collect(Collectors.toList());
-
-        List<Double> temperatureValues = temperaturas.stream()
-            .map(DatosTemperatura::getTemperatura)
-            .collect(Collectors.toList());
-
-        SerieDatos wind = new SerieDatos(labels, windValues);
-        SerieDatos humidity = new SerieDatos(labels, humidityValues);
-        SerieDatos temperature = new SerieDatos(labels, temperatureValues);
-
-        return new DatosMeteorologicosDTO(wind, humidity, temperature);
+        return dashboardDataService.obtenerSeries();
     }
 }

--- a/app/src/main/java/org/javadominicano/dto/DashboardUpdateDTO.java
+++ b/app/src/main/java/org/javadominicano/dto/DashboardUpdateDTO.java
@@ -1,0 +1,32 @@
+package org.javadominicano.dto;
+
+import org.javadominicano.dto.DatosMeteorologicosDTO;
+import org.javadominicano.visualizadorweb.dto.MedicionesRecientesDTO;
+
+public class DashboardUpdateDTO {
+    private DatosMeteorologicosDTO datos;
+    private MedicionesRecientesDTO mediciones;
+
+    public DashboardUpdateDTO() {}
+
+    public DashboardUpdateDTO(DatosMeteorologicosDTO datos, MedicionesRecientesDTO mediciones) {
+        this.datos = datos;
+        this.mediciones = mediciones;
+    }
+
+    public DatosMeteorologicosDTO getDatos() {
+        return datos;
+    }
+
+    public void setDatos(DatosMeteorologicosDTO datos) {
+        this.datos = datos;
+    }
+
+    public MedicionesRecientesDTO getMediciones() {
+        return mediciones;
+    }
+
+    public void setMediciones(MedicionesRecientesDTO mediciones) {
+        this.mediciones = mediciones;
+    }
+}

--- a/app/src/main/java/org/javadominicano/servicios/DashboardDataService.java
+++ b/app/src/main/java/org/javadominicano/servicios/DashboardDataService.java
@@ -1,0 +1,79 @@
+package org.javadominicano.servicios;
+
+import org.javadominicano.dto.DatosMeteorologicosDTO;
+import org.javadominicano.dto.DatosMeteorologicosDTO.SerieDatos;
+import org.javadominicano.visualizadorweb.dto.MedicionesRecientesDTO;
+import org.javadominicano.entidades.*;
+import org.javadominicano.repositorios.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+public class DashboardDataService {
+
+    @Autowired private DatosVelocidadRepository repoVelocidad;
+    @Autowired private DatosHumedadRepository repoHumedad;
+    @Autowired private DatosTemperaturaRepository repoTemperatura;
+
+    @Autowired private RepositorioDatosDireccion repoDireccion;
+    @Autowired private RepositorioDatosPrecipitacion repoPrecipitacion;
+
+    private DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+
+    public DatosMeteorologicosDTO obtenerSeries() {
+        List<DatosVelocidad> velocidades = repoVelocidad.findTop30ByOrderByFechaDesc();
+        List<DatosHumedad> humedades = repoHumedad.findTop30ByOrderByFechaDesc();
+        List<DatosTemperatura> temperaturas = repoTemperatura.findTop30ByOrderByFechaDesc();
+
+        velocidades.sort(Comparator.comparing(DatosVelocidad::getFecha));
+        humedades.sort(Comparator.comparing(DatosHumedad::getFecha));
+        temperaturas.sort(Comparator.comparing(DatosTemperatura::getFecha));
+
+        List<String> labels = velocidades.stream()
+            .map(d -> d.getFecha().toLocalDateTime().format(formatter))
+            .collect(Collectors.toList());
+
+        List<Double> windValues = velocidades.stream()
+            .map(DatosVelocidad::getVelocidad)
+            .collect(Collectors.toList());
+
+        List<Double> humidityValues = humedades.stream()
+            .map(DatosHumedad::getHumedad)
+            .collect(Collectors.toList());
+
+        List<Double> temperatureValues = temperaturas.stream()
+            .map(DatosTemperatura::getTemperatura)
+            .collect(Collectors.toList());
+
+        SerieDatos wind = new SerieDatos(labels, windValues);
+        SerieDatos humidity = new SerieDatos(labels, humidityValues);
+        SerieDatos temperature = new SerieDatos(labels, temperatureValues);
+
+        return new DatosMeteorologicosDTO(wind, humidity, temperature);
+    }
+
+    public MedicionesRecientesDTO obtenerMediciones() {
+        MedicionesRecientesDTO dto = new MedicionesRecientesDTO();
+        dto.setTemperatura(
+            repoTemperatura.findTopByOrderByFechaDesc(PageRequest.of(0,1)).get(0).getTemperatura()
+        );
+        dto.setHumedad(
+            repoHumedad.findTopByOrderByFechaDesc(PageRequest.of(0,1)).get(0).getHumedad()
+        );
+        dto.setVelocidadViento(
+            repoVelocidad.findTopByOrderByFechaDesc(PageRequest.of(0,1)).get(0).getVelocidad()
+        );
+        dto.setDireccionViento(
+            repoDireccion.findTopByOrderByFechaDesc(PageRequest.of(0,1)).get(0).getDireccion()
+        );
+        dto.setPrecipitacion(
+            repoPrecipitacion.findTopByOrderByFechaDesc(PageRequest.of(0,1)).get(0).getProbabilidad()
+        );
+        return dto;
+    }
+}

--- a/app/src/main/java/org/javadominicano/servicios/DashboardWebSocketPublisher.java
+++ b/app/src/main/java/org/javadominicano/servicios/DashboardWebSocketPublisher.java
@@ -1,0 +1,25 @@
+package org.javadominicano.servicios;
+
+import org.javadominicano.dto.DashboardUpdateDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DashboardWebSocketPublisher {
+
+    @Autowired
+    private DashboardDataService dashboardDataService;
+
+    @Autowired
+    private SimpMessagingTemplate messagingTemplate;
+
+    @Scheduled(fixedRate = 8000)
+    public void publishUpdate() {
+        DashboardUpdateDTO dto = new DashboardUpdateDTO(
+                dashboardDataService.obtenerSeries(),
+                dashboardDataService.obtenerMediciones());
+        messagingTemplate.convertAndSend("/topic/dashboard", dto);
+    }
+}

--- a/app/src/main/resources/templates/dashboard.html
+++ b/app/src/main/resources/templates/dashboard.html
@@ -8,6 +8,8 @@
         rel="stylesheet" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/stompjs@2/dist/stomp.min.js"></script>
     <style>
         * {
             margin: 0;
@@ -367,7 +369,7 @@
                 <circle cx="12" cy="18" r="3" />
                 <path d="M12 15V5a2 2 0 1 1 4 0v5" />
             </svg>
-            <p th:text="${mediciones.temperatura + '°C'}">33.94°C</p>
+            <p id="tempValue" th:text="${mediciones.temperatura + '°C'}">33.94°C</p>
             <span>Temperatura</span>
         </div>
         <div class="card">
@@ -375,7 +377,7 @@
                 <path d="M12 3s-5 6-5 9a5 5 0 0 0 10 0c0-3-5-9-5-9z" />
                 <path d="M14 10.5a2 2 0 1 1-4 0c0-1.5 2-4.5 2-4.5s2 3 2 4.5z" opacity="0.6" />
             </svg>
-            <p th:text="${mediciones.humedad + '%'}">80.75%</p>
+            <p id="humValue" th:text="${mediciones.humedad + '%'}">80.75%</p>
             <span>Humedad</span>
         </div>
         <div class="card">
@@ -383,7 +385,7 @@
                 <path d="M3 7h9a4 4 0 1 0-4-4" />
                 <path d="M2 14h12a4 4 0 1 1-3 6" />
             </svg>
-            <p th:text="${mediciones.velocidadViento + ' Km/h'}">43.99 Km/h</p>
+            <p id="windSpeedValue" th:text="${mediciones.velocidadViento + ' Km/h'}">43.99 Km/h</p>
             <span>Velocidad del Viento</span>
         </div>
         <div class="card">
@@ -391,7 +393,7 @@
                 <circle cx="12" cy="12" r="8" />
                 <path d="M12 8l-3 4h2v4h2v-4h2l-3-4z" />
             </svg>
-            <p th:text="${mediciones.direccionViento}">Sureste</p>
+            <p id="windDirValue" th:text="${mediciones.direccionViento}">Sureste</p>
             <span>Dirección del Viento</span>
         </div>
         <div class="card">
@@ -401,7 +403,7 @@
                 <path d="M12 16v3" />
                 <path d="M16 16v3" />
             </svg>
-            <p th:text="${#numbers.formatDecimal(mediciones.precipitacion, 1, 1) + 'mm'}">75.6mm</p>
+            <p id="precValue" th:text="${#numbers.formatDecimal(mediciones.precipitacion, 1, 1) + 'mm'}">75.6mm</p>
             <span>Precipitación</span>
         </div>
     </div>
@@ -616,40 +618,42 @@ const temperatureChart = new Chart(temperatureCtx, {
     }
 });
 
-// Función para actualizar las gráficas con datos reales desde el backend
-function updateCharts() {
-    fetch('/api/datos-meteorologicos')
-        .then(response => {
-            if (!response.ok) throw new Error('Respuesta no OK');
-            return response.json();
-        })
-        .then(data => {
-            // Actualizar gráfica de viento
-            windChart.data.labels = data.wind.labels;
-            windChart.data.datasets[0].data = data.wind.values;
-            windChart.update();
+function updateFromServer(payload) {
+    const data = payload.datos;
+    const mediciones = payload.mediciones;
 
-            // Actualizar gráfica de humedad
-            humidityChart.data.labels = data.humidity.labels;
-            humidityChart.data.datasets[0].data = data.humidity.values;
-            humidityChart.update();
+    windChart.data.labels = data.wind.labels;
+    windChart.data.datasets[0].data = data.wind.values;
+    windChart.update();
 
-            // Actualizar gráfica de temperatura
-            temperatureChart.data.labels = data.temperature.labels;
-            temperatureChart.data.datasets[0].data = data.temperature.values;
-            temperatureChart.update();
-        })
-        .catch(error => {
-            console.error('Error al obtener datos meteorológicos:', error);
-            // Opcional: puedes dejar las gráficas con datos de ejemplo o mostrar un mensaje al usuario
-        });
+    humidityChart.data.labels = data.humidity.labels;
+    humidityChart.data.datasets[0].data = data.humidity.values;
+    humidityChart.update();
+
+    temperatureChart.data.labels = data.temperature.labels;
+    temperatureChart.data.datasets[0].data = data.temperature.values;
+    temperatureChart.update();
+
+    if (mediciones) {
+        document.getElementById('tempValue').textContent = mediciones.temperatura + '°C';
+        document.getElementById('humValue').textContent = mediciones.humedad + '%';
+        document.getElementById('windSpeedValue').textContent = mediciones.velocidadViento + ' Km/h';
+        document.getElementById('windDirValue').textContent = mediciones.direccionViento;
+        document.getElementById('precValue').textContent = mediciones.precipitacion.toFixed(1) + 'mm';
+    }
 }
 
-// Actualizar gráficas cada 30 segundos con datos reales
-setInterval(updateCharts, 30000);
-
-// Actualizar inmediatamente al cargar la página
-updateCharts();
+const socket = new SockJS('/ws');
+const stompClient = Stomp.over(socket);
+stompClient.connect({}, function () {
+    stompClient.subscribe('/topic/dashboard', function (message) {
+        updateFromServer(JSON.parse(message.body));
+    });
+    // Obtener datos iniciales
+    fetch('/api/datos-meteorologicos')
+        .then(r => r.json())
+        .then(data => updateFromServer({datos: data}));
+});
 </script>
 
 


### PR DESCRIPTION
## Summary
- add WebSocket starter dependency
- implement `DashboardDataService` with latest measurements and series
- publish dashboard data every 8 seconds with `DashboardWebSocketPublisher`
- enable scheduling and configure STOMP WebSocket
- expose series data through updated controller
- update dashboard page to subscribe to `/topic/dashboard` and update cards and charts

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686be311ebfc83229dcca77953d0c2b6