### PR TITLE
Implement station status change alerts

### DIFF
--- a/app/src/main/java/org/javadominicano/controladores/EstadoEstacionesController.java
+++ b/app/src/main/java/org/javadominicano/controladores/EstadoEstacionesController.java
@@ -1,0 +1,21 @@
+package org.javadominicano.controladores;
+
+import org.javadominicano.dto.EstadoEstacionDTO;
+import org.javadominicano.servicios.EstadoEstacionesService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class EstadoEstacionesController {
+
+    @Autowired
+    private EstadoEstacionesService estadoService;
+
+    @GetMapping("/api/estado-estaciones")
+    public List<EstadoEstacionDTO> obtenerEstados() {
+        return estadoService.obtenerEstados();
+    }
+}

--- a/app/src/main/java/org/javadominicano/dto/EstadoEstacionDTO.java
+++ b/app/src/main/java/org/javadominicano/dto/EstadoEstacionDTO.java
@@ -1,0 +1,31 @@
+package org.javadominicano.dto;
+
+public class EstadoEstacionDTO {
+    private String id;
+    private String nombre;
+    private boolean activa;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public boolean isActiva() {
+        return activa;
+    }
+
+    public void setActiva(boolean activa) {
+        this.activa = activa;
+    }
+}

--- a/app/src/main/java/org/servicios/EstadoEstacionesService.java
+++ b/app/src/main/java/org/servicios/EstadoEstacionesService.java
@@ -1,0 +1,75 @@
+package org.javadominicano.servicios;
+
+import org.javadominicano.dto.EstadoEstacionDTO;
+import org.javadominicano.entidades.EstacionMeteorologica;
+import org.javadominicano.repositorios.RepositorioEstacionMeteorologica;
+import org.javadominicano.repositorios.RepositorioDatosDireccion;
+import org.javadominicano.repositorios.RepositorioDatosPrecipitacion;
+import org.javadominicano.repositorios.RepositorioDatosVelocidad;
+import org.javadominicano.visualizadorweb.repositorios.RepositorioDatosHumedad;
+import org.javadominicano.visualizadorweb.repositorios.RepositorioDatosTemperatura;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+@Service
+public class EstadoEstacionesService {
+    @Autowired
+    private RepositorioDatosVelocidad repoVelocidad;
+    @Autowired
+    private RepositorioDatosDireccion repoDireccion;
+    @Autowired
+    private RepositorioDatosPrecipitacion repoPrecipitacion;
+    @Autowired
+    private RepositorioDatosHumedad repoHumedad;
+    @Autowired
+    private RepositorioDatosTemperatura repoTemperatura;
+    @Autowired
+    private RepositorioEstacionMeteorologica repoEstacion;
+
+    public List<EstadoEstacionDTO> obtenerEstados() {
+        Date ahora = new Date();
+        Date limite = new Date(ahora.getTime() - 30_000L);
+        List<EstadoEstacionDTO> lista = new ArrayList<>();
+        for (EstacionMeteorologica e : repoEstacion.findAll()) {
+            Date ultima = obtenerUltimaFechaEstacion(e.getId());
+            boolean activa = ultima != null && ultima.after(limite);
+            EstadoEstacionDTO dto = new EstadoEstacionDTO();
+            dto.setId(e.getId());
+            dto.setNombre(e.getNombre());
+            dto.setActiva(activa);
+            lista.add(dto);
+        }
+        return lista;
+    }
+
+    private Date obtenerUltimaFechaEstacion(String estacionId) {
+        Date ultima = null;
+        Timestamp t;
+        t = repoTemperatura.findUltimaFechaByEstacion(estacionId);
+        if (t != null && (ultima == null || t.after(ultima))) {
+            ultima = t;
+        }
+        t = repoHumedad.findUltimaFechaByEstacion(estacionId);
+        if (t != null && (ultima == null || t.after(ultima))) {
+            ultima = t;
+        }
+        t = repoVelocidad.findUltimaFechaByEstacion(estacionId);
+        if (t != null && (ultima == null || t.after(ultima))) {
+            ultima = t;
+        }
+        t = repoDireccion.findUltimaFechaByEstacion(estacionId);
+        if (t != null && (ultima == null || t.after(ultima))) {
+            ultima = t;
+        }
+        t = repoPrecipitacion.findUltimaFechaByEstacion(estacionId);
+        if (t != null && (ultima == null || t.after(ultima))) {
+            ultima = t;
+        }
+        return ultima;
+    }
+}

--- a/app/src/main/resources/templates/fragments/alertasActivas.html
+++ b/app/src/main/resources/templates/fragments/alertasActivas.html
@@ -1,13 +1,14 @@
 <div th:fragment="alertas">
     <style>
         .alert-card {
-            background-color: #dc3545;
             color: white;
             padding: 10px 15px;
             border-radius: 5px;
             margin-bottom: 10px;
             position: relative;
         }
+        .alert-card.danger { background-color: #dc3545; }
+        .alert-card.success { background-color: #28a745; }
         .alert-card button {
             position: absolute;
             top: 5px;
@@ -21,7 +22,7 @@
     </style>
 
     <div th:if="${alertasActivas != null}" id="alertContainer">
-        <div th:each="a : ${alertasActivas}" class="alert-card"
+        <div th:each="a : ${alertasActivas}" class="alert-card danger"
              th:attr="data-key=${'alert_'+ a.alerta.id +'_'+ a.fecha.time}">
             <span th:text="${a.alerta.nombre == 'Temperatura' ? 'Umbral de temperatura superado' :
                              a.alerta.nombre == 'Humedad' ? 'Umbral de humedad superado' :
@@ -30,6 +31,8 @@
             <button type="button" class="close-alert">&times;</button>
         </div>
     </div>
+
+    <div id="estadoAlertContainer"></div>
 
     <script th:inline="javascript">
     /*<![CDATA[*/
@@ -49,6 +52,47 @@
         }
         setTimeout(markAsShown, 7000);
     });
+
+    function mostrarAlertaEstado(nombre, activa) {
+        var cont = document.getElementById('estadoAlertContainer');
+        if (!cont) return;
+        var card = document.createElement('div');
+        card.className = 'alert-card ' + (activa ? 'success' : 'danger');
+        var span = document.createElement('span');
+        span.textContent = activa ?
+            'La estación ' + nombre + ' se ha reconectado correctamente.' :
+            'La estación ' + nombre + ' se ha desconectado.';
+        var btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'close-alert';
+        btn.innerHTML = '&times;';
+        card.appendChild(span);
+        card.appendChild(btn);
+        cont.appendChild(card);
+        var remove = function() { card.remove(); };
+        btn.addEventListener('click', remove);
+        setTimeout(remove, 7000);
+    }
+
+    function checkEstados() {
+        fetch('/api/estado-estaciones')
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                var prev = JSON.parse(localStorage.getItem('estados_estaciones') || '{}');
+                data.forEach(function(e) {
+                    var before = prev[e.id];
+                    if (before !== undefined && before !== e.activa) {
+                        mostrarAlertaEstado(e.nombre, e.activa);
+                    }
+                    prev[e.id] = e.activa;
+                });
+                localStorage.setItem('estados_estaciones', JSON.stringify(prev));
+            })
+            .catch(function(err) { console.error(err); });
+    }
+
+    checkEstados();
+    setInterval(checkEstados, 30000);
     /*]]>*/
     </script>
 </div>


### PR DESCRIPTION
## Summary
- add `EstadoEstacionDTO` DTO for station status
- implement `EstadoEstacionesService` service to evaluate station activity
- expose `/api/estado-estaciones` REST endpoint
- extend alert fragment to show alerts when stations connect/disconnect

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686c7e0cd2c883229452c1bda45798d5