### PR TITLE
Add station activation toggle

### DIFF
--- a/app/src/main/java/org/javadominicano/controladores/VisualizadorController.java
+++ b/app/src/main/java/org/javadominicano/controladores/VisualizadorController.java
@@ -296,6 +296,16 @@ public class VisualizadorController {
         return "redirect:/estaciones";
     }
 
+    @PostMapping("/estaciones/toggle")
+    public String toggleEstacion(@RequestParam String id) {
+        EstacionMeteorologica estacion = repositorioEstacion.findById(id).orElse(null);
+        if (estacion != null) {
+            estacion.setHabilitada(!estacion.isHabilitada());
+            repositorioEstacion.save(estacion);
+        }
+        return "redirect:/estaciones";
+    }
+
     // Mostrar formulario de edición
     @GetMapping("/estaciones/editar")
     public String mostrarEditarEstacion(@RequestParam String id, Model model) {

--- a/app/src/main/java/org/javadominicano/entidades/EstacionMeteorologica.java
+++ b/app/src/main/java/org/javadominicano/entidades/EstacionMeteorologica.java
@@ -18,6 +18,9 @@ public class EstacionMeteorologica {
     @Column(name = "ubicacion")
     private String ubicacion;
 
+    @Column(name = "habilitada")
+    private boolean habilitada = true;
+
     // Constructor vacío (necesario para Thymeleaf)
     public EstacionMeteorologica() {
     }
@@ -50,4 +53,11 @@ public class EstacionMeteorologica {
     public void setUbicacion(String ubicacion) {
         this.ubicacion = ubicacion;
     }
-}
+
+    public boolean isHabilitada() {
+        return habilitada;
+    }
+
+    public void setHabilitada(boolean habilitada) {
+        this.habilitada = habilitada;
+    }}

--- a/app/src/main/resources/templates/estaciones.html
+++ b/app/src/main/resources/templates/estaciones.html
@@ -201,6 +201,11 @@
                         <button type="button" class="edit open-edit"
                                 th:data-id="${estacion.id}" th:data-nombre="${estacion.nombre}"
                                 th:data-ubicacion="${estacion.ubicacion}">✏️</button>
+                        <form th:action="@{/estaciones/toggle}" method="post" style="display:inline">
+                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                            <input type="hidden" name="id" th:value="${estacion.id}" />
+                            <button type="submit" th:text="${estacion.habilitada} ? 'Desactivar' : 'Activar'"></button>
+                        </form>
                     </td>
                 </tr>
                 <tr th:if="${#lists.isEmpty(estaciones)}">


### PR DESCRIPTION
## Summary
- add `habilitada` property to EstacionMeteorologica entity
- allow toggling station state in VisualizadorController
- include toggle form in estaciones table

## Testing
- `./gradlew test` *(fails: unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_686dd175162c8322b085652c7961ea39