### PR TITLE
Adjust inactive station timeout

### DIFF
--- a/app/bin/main/templates/dashboard.html
+++ b/app/bin/main/templates/dashboard.html
@@ -661,8 +661,8 @@ function updateCharts() {
         });
 }
 
-// Actualizar gráficas cada 30 segundos con datos reales
-setInterval(updateCharts, 30000);
+// Actualizar gráficas cada 12 segundos con datos reales
+setInterval(updateCharts, 12000);
 
 // Actualizar inmediatamente al cargar la página
 updateCharts();

--- a/app/bin/main/templates/fragments/alertasActivas.html
+++ b/app/bin/main/templates/fragments/alertasActivas.html
@@ -94,7 +94,7 @@
     }
 
     checkEstados();
-    setInterval(checkEstados, 30000);
+    setInterval(checkEstados, 12000);
     /*]]>*/
     </script>
 </div>

--- a/app/src/main/java/org/javadominicano/controladores/VisualizadorController.java
+++ b/app/src/main/java/org/javadominicano/controladores/VisualizadorController.java
@@ -194,9 +194,9 @@ public class VisualizadorController {
             repositorioHumedadSuelo.findTopByOrderByFechaDesc(PageRequest.of(0,1)).get(0).getHumedad()
         );
 
-        // Fecha límite para considerar una estación activa (30 segundos)
+        // Fecha límite para considerar una estación activa (12 segundos)
         Date ahora = new Date();
-        Date fechaLimite = new Date(ahora.getTime() - 30_000L);
+        Date fechaLimite = new Date(ahora.getTime() - 12_000L);
 
         List<EstacionMeteorologica> todasEstaciones = repositorioEstacion.findAll();
         int estacionesActivas = 0;
@@ -335,7 +335,7 @@ public class VisualizadorController {
     @GetMapping("/estaciones")
     public String listarEstaciones(Model model) {
         Date ahora = new Date();
-        Date fechaLimite = new Date(ahora.getTime() - 30_000L);
+        Date fechaLimite = new Date(ahora.getTime() - 12_000L);
 
         int estacionesActivas = 0;
         int estacionesInactivas = 0;

--- a/app/src/main/java/org/servicios/EstadoEstacionesService.java
+++ b/app/src/main/java/org/servicios/EstadoEstacionesService.java
@@ -35,7 +35,7 @@ public class EstadoEstacionesService {
 
     public List<EstadoEstacionDTO> obtenerEstados() {
         Date ahora = new Date();
-        Date limite = new Date(ahora.getTime() - 30_000L);
+        Date limite = new Date(ahora.getTime() - 12_000L);
         List<EstadoEstacionDTO> lista = new ArrayList<>();
         for (EstacionMeteorologica e : repoEstacion.findAll()) {
             Date ultima = obtenerUltimaFechaEstacion(e.getId());

--- a/app/src/main/resources/templates/dashboard.html
+++ b/app/src/main/resources/templates/dashboard.html
@@ -661,8 +661,8 @@ function updateCharts() {
         });
 }
 
-// Actualizar gráficas cada 30 segundos con datos reales
-setInterval(updateCharts, 30000);
+// Actualizar gráficas cada 12 segundos con datos reales
+setInterval(updateCharts, 12000);
 
 // Actualizar inmediatamente al cargar la página
 updateCharts();

--- a/app/src/main/resources/templates/fragments/alertasActivas.html
+++ b/app/src/main/resources/templates/fragments/alertasActivas.html
@@ -94,7 +94,7 @@
     }
 
     checkEstados();
-    setInterval(checkEstados, 30000);
+    setInterval(checkEstados, 12000);
     /*]]>*/
     </script>
 </div>


### PR DESCRIPTION
## Summary
- shorten timeout threshold for inactive stations
- update dashboard refresh rate

## Testing
- `gradle test` *(fails: Plugin not found due to lack of network access)*

------
https://chatgpt.com/codex/tasks/task_e_68703c0bb8308322bed7b8d3bc4aecd6