### PR TITLE
Add summary rows to report tables

### DIFF
--- a/app/src/main/java/org/javadominicano/controladores/ReportesController.java
+++ b/app/src/main/java/org/javadominicano/controladores/ReportesController.java
@@ -18,6 +18,13 @@ import java.util.DoubleSummaryStatistics;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Sort;
+import org.javadominicano.entidades.DatosDireccion;
+import org.javadominicano.entidades.DatosPrecipitacion;
+import org.javadominicano.entidades.DatosVelocidad;
+import org.javadominicano.visualizadorweb.entidades.DatosHumedad;
+import org.javadominicano.visualizadorweb.entidades.DatosTemperatura;
+import org.javadominicano.visualizadorweb.entidades.DatosPresion;
+import org.javadominicano.visualizadorweb.entidades.DatosHumedadSuelo;
 
 import org.javadominicano.repositorios.RepositorioDatosVelocidad;
 import org.javadominicano.repositorios.RepositorioDatosDireccion;
@@ -173,13 +180,13 @@ public class ReportesController {
         PageRequest pr = PageRequest.of(paginaActual, tamanoPagina, sort);
 
         model.addAttribute("reporte", rep);
-        Page<?> velocidadesPage = repoVelocidad.findByFechaBetween(inicio, fin, pr);
-        Page<?> direccionesPage = repoDireccion.findByFechaBetween(inicio, fin, pr);
-        Page<?> precipitacionesPage = repoPrecipitacion.findByFechaBetween(inicio, fin, pr);
-        Page<?> humedadesPage = repoHumedad.findByFechaBetween(inicio, fin, pr);
-        Page<?> temperaturasPage = repoTemperatura.findByFechaBetween(inicio, fin, pr);
-        Page<?> presionesPage = repoPresion.findByFechaBetween(inicio, fin, pr);
-        Page<?> humedadesSueloPage = repoHumedadSuelo.findByFechaBetween(inicio, fin, pr);
+        Page<DatosVelocidad> velocidadesPage = repoVelocidad.findByFechaBetween(inicio, fin, pr);
+        Page<DatosDireccion> direccionesPage = repoDireccion.findByFechaBetween(inicio, fin, pr);
+        Page<DatosPrecipitacion> precipitacionesPage = repoPrecipitacion.findByFechaBetween(inicio, fin, pr);
+        Page<DatosHumedad> humedadesPage = repoHumedad.findByFechaBetween(inicio, fin, pr);
+        Page<DatosTemperatura> temperaturasPage = repoTemperatura.findByFechaBetween(inicio, fin, pr);
+        Page<DatosPresion> presionesPage = repoPresion.findByFechaBetween(inicio, fin, pr);
+        Page<DatosHumedadSuelo> humedadesSueloPage = repoHumedadSuelo.findByFechaBetween(inicio, fin, pr);
 
         // Calcular dirección más frecuente
         String dirFrecuente = repoDireccion
@@ -200,24 +207,18 @@ public class ReportesController {
         model.addAttribute("humedadesSuelo", humedadesSueloPage);
         model.addAttribute("dirFrecuente", dirFrecuente);
 
-        DoubleSummaryStatistics statsVel = repoVelocidad
-                .findByFechaBetweenOrderByFechaDesc(inicio, fin)
-                .stream().mapToDouble(v -> v.getVelocidad()).summaryStatistics();
-        DoubleSummaryStatistics statsPre = repoPrecipitacion
-                .findByFechaBetweenOrderByFechaDesc(inicio, fin)
-                .stream().mapToDouble(p -> p.getProbabilidad()).summaryStatistics();
-        DoubleSummaryStatistics statsHum = repoHumedad
-                .findByFechaBetweenOrderByFechaDesc(inicio, fin)
-                .stream().mapToDouble(h -> h.getHumedad()).summaryStatistics();
-        DoubleSummaryStatistics statsTem = repoTemperatura
-                .findByFechaBetweenOrderByFechaDesc(inicio, fin)
-                .stream().mapToDouble(t -> t.getTemperatura()).summaryStatistics();
-        DoubleSummaryStatistics statsPreS = repoPresion
-                .findByFechaBetweenOrderByFechaDesc(inicio, fin)
-                .stream().mapToDouble(p -> p.getPresion()).summaryStatistics();
-        DoubleSummaryStatistics statsHumS = repoHumedadSuelo
-                .findByFechaBetweenOrderByFechaDesc(inicio, fin)
-                .stream().mapToDouble(hs -> hs.getHumedad()).summaryStatistics();
+        DoubleSummaryStatistics statsVel = velocidadesPage.getContent().stream()
+                .mapToDouble(DatosVelocidad::getVelocidad).summaryStatistics();
+        DoubleSummaryStatistics statsPre = precipitacionesPage.getContent().stream()
+                .mapToDouble(DatosPrecipitacion::getProbabilidad).summaryStatistics();
+        DoubleSummaryStatistics statsHum = humedadesPage.getContent().stream()
+                .mapToDouble(DatosHumedad::getHumedad).summaryStatistics();
+        DoubleSummaryStatistics statsTem = temperaturasPage.getContent().stream()
+                .mapToDouble(DatosTemperatura::getTemperatura).summaryStatistics();
+        DoubleSummaryStatistics statsPreS = presionesPage.getContent().stream()
+                .mapToDouble(DatosPresion::getPresion).summaryStatistics();
+        DoubleSummaryStatistics statsHumS = humedadesSueloPage.getContent().stream()
+                .mapToDouble(DatosHumedadSuelo::getHumedad).summaryStatistics();
 
         model.addAttribute("velMin", statsVel.getCount() > 0 ? statsVel.getMin() : null);
         model.addAttribute("velMax", statsVel.getCount() > 0 ? statsVel.getMax() : null);

--- a/app/src/main/java/org/javadominicano/controladores/ReportesController.java
+++ b/app/src/main/java/org/javadominicano/controladores/ReportesController.java
@@ -15,6 +15,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import java.util.DoubleSummaryStatistics;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Sort;
 
 import org.javadominicano.repositorios.RepositorioDatosVelocidad;
@@ -179,6 +181,16 @@ public class ReportesController {
         Page<?> presionesPage = repoPresion.findByFechaBetween(inicio, fin, pr);
         Page<?> humedadesSueloPage = repoHumedadSuelo.findByFechaBetween(inicio, fin, pr);
 
+        // Calcular dirección más frecuente
+        String dirFrecuente = repoDireccion
+                .findByFechaBetweenOrderByFechaDesc(inicio, fin)
+                .stream()
+                .collect(Collectors.groupingBy(d -> d.getDireccion(), Collectors.counting()))
+                .entrySet().stream()
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse(null);
+
         model.addAttribute("velocidades", velocidadesPage);
         model.addAttribute("direcciones", direccionesPage);
         model.addAttribute("precipitaciones", precipitacionesPage);
@@ -186,6 +198,7 @@ public class ReportesController {
         model.addAttribute("temperaturas", temperaturasPage);
         model.addAttribute("presiones", presionesPage);
         model.addAttribute("humedadesSuelo", humedadesSueloPage);
+        model.addAttribute("dirFrecuente", dirFrecuente);
 
         DoubleSummaryStatistics statsVel = repoVelocidad
                 .findByFechaBetweenOrderByFechaDesc(inicio, fin)

--- a/app/src/main/java/org/javadominicano/controladores/ReportesController.java
+++ b/app/src/main/java/org/javadominicano/controladores/ReportesController.java
@@ -14,6 +14,7 @@ import org.springframework.http.MediaType;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import java.util.DoubleSummaryStatistics;
 import org.springframework.data.domain.Sort;
 
 import org.javadominicano.repositorios.RepositorioDatosVelocidad;
@@ -170,13 +171,59 @@ public class ReportesController {
         PageRequest pr = PageRequest.of(paginaActual, tamanoPagina, sort);
 
         model.addAttribute("reporte", rep);
-        model.addAttribute("velocidades", repoVelocidad.findByFechaBetween(inicio, fin, pr));
-        model.addAttribute("direcciones", repoDireccion.findByFechaBetween(inicio, fin, pr));
-        model.addAttribute("precipitaciones", repoPrecipitacion.findByFechaBetween(inicio, fin, pr));
-        model.addAttribute("humedades", repoHumedad.findByFechaBetween(inicio, fin, pr));
-        model.addAttribute("temperaturas", repoTemperatura.findByFechaBetween(inicio, fin, pr));
-        model.addAttribute("presiones", repoPresion.findByFechaBetween(inicio, fin, pr));
-        model.addAttribute("humedadesSuelo", repoHumedadSuelo.findByFechaBetween(inicio, fin, pr));
+        Page<?> velocidadesPage = repoVelocidad.findByFechaBetween(inicio, fin, pr);
+        Page<?> direccionesPage = repoDireccion.findByFechaBetween(inicio, fin, pr);
+        Page<?> precipitacionesPage = repoPrecipitacion.findByFechaBetween(inicio, fin, pr);
+        Page<?> humedadesPage = repoHumedad.findByFechaBetween(inicio, fin, pr);
+        Page<?> temperaturasPage = repoTemperatura.findByFechaBetween(inicio, fin, pr);
+        Page<?> presionesPage = repoPresion.findByFechaBetween(inicio, fin, pr);
+        Page<?> humedadesSueloPage = repoHumedadSuelo.findByFechaBetween(inicio, fin, pr);
+
+        model.addAttribute("velocidades", velocidadesPage);
+        model.addAttribute("direcciones", direccionesPage);
+        model.addAttribute("precipitaciones", precipitacionesPage);
+        model.addAttribute("humedades", humedadesPage);
+        model.addAttribute("temperaturas", temperaturasPage);
+        model.addAttribute("presiones", presionesPage);
+        model.addAttribute("humedadesSuelo", humedadesSueloPage);
+
+        DoubleSummaryStatistics statsVel = repoVelocidad
+                .findByFechaBetweenOrderByFechaDesc(inicio, fin)
+                .stream().mapToDouble(v -> v.getVelocidad()).summaryStatistics();
+        DoubleSummaryStatistics statsPre = repoPrecipitacion
+                .findByFechaBetweenOrderByFechaDesc(inicio, fin)
+                .stream().mapToDouble(p -> p.getProbabilidad()).summaryStatistics();
+        DoubleSummaryStatistics statsHum = repoHumedad
+                .findByFechaBetweenOrderByFechaDesc(inicio, fin)
+                .stream().mapToDouble(h -> h.getHumedad()).summaryStatistics();
+        DoubleSummaryStatistics statsTem = repoTemperatura
+                .findByFechaBetweenOrderByFechaDesc(inicio, fin)
+                .stream().mapToDouble(t -> t.getTemperatura()).summaryStatistics();
+        DoubleSummaryStatistics statsPreS = repoPresion
+                .findByFechaBetweenOrderByFechaDesc(inicio, fin)
+                .stream().mapToDouble(p -> p.getPresion()).summaryStatistics();
+        DoubleSummaryStatistics statsHumS = repoHumedadSuelo
+                .findByFechaBetweenOrderByFechaDesc(inicio, fin)
+                .stream().mapToDouble(hs -> hs.getHumedad()).summaryStatistics();
+
+        model.addAttribute("velMin", statsVel.getCount() > 0 ? statsVel.getMin() : null);
+        model.addAttribute("velMax", statsVel.getCount() > 0 ? statsVel.getMax() : null);
+        model.addAttribute("velAvg", statsVel.getCount() > 0 ? statsVel.getAverage() : null);
+        model.addAttribute("preMin", statsPre.getCount() > 0 ? statsPre.getMin() : null);
+        model.addAttribute("preMax", statsPre.getCount() > 0 ? statsPre.getMax() : null);
+        model.addAttribute("preAvg", statsPre.getCount() > 0 ? statsPre.getAverage() : null);
+        model.addAttribute("humMin", statsHum.getCount() > 0 ? statsHum.getMin() : null);
+        model.addAttribute("humMax", statsHum.getCount() > 0 ? statsHum.getMax() : null);
+        model.addAttribute("humAvg", statsHum.getCount() > 0 ? statsHum.getAverage() : null);
+        model.addAttribute("temMin", statsTem.getCount() > 0 ? statsTem.getMin() : null);
+        model.addAttribute("temMax", statsTem.getCount() > 0 ? statsTem.getMax() : null);
+        model.addAttribute("temAvg", statsTem.getCount() > 0 ? statsTem.getAverage() : null);
+        model.addAttribute("presMin", statsPreS.getCount() > 0 ? statsPreS.getMin() : null);
+        model.addAttribute("presMax", statsPreS.getCount() > 0 ? statsPreS.getMax() : null);
+        model.addAttribute("presAvg", statsPreS.getCount() > 0 ? statsPreS.getAverage() : null);
+        model.addAttribute("humSMin", statsHumS.getCount() > 0 ? statsHumS.getMin() : null);
+        model.addAttribute("humSMax", statsHumS.getCount() > 0 ? statsHumS.getMax() : null);
+        model.addAttribute("humSAvg", statsHumS.getCount() > 0 ? statsHumS.getAverage() : null);
         model.addAttribute("paginaActual", paginaActual);
         model.addAttribute("tamanoPagina", tamanoPagina);
 

--- a/app/src/main/resources/templates/reportePreview.html
+++ b/app/src/main/resources/templates/reportePreview.html
@@ -64,6 +64,13 @@
                             <td th:text="${v.velocidad}"></td>
                             <td th:text="${v.fecha}"></td>
                         </tr>
+                        <tr style="background-color:#f0f0f0;font-weight:bold;">
+                            <td colspan="3">
+                                Mínimo: <span th:text="${velMin}"></span> |
+                                Máximo: <span th:text="${velMax}"></span> |
+                                Promedio: <span th:text="${velAvg}"></span>
+                            </td>
+                        </tr>
                     </tbody>
                 </table>
             </div>
@@ -90,6 +97,13 @@
                             <td th:text="${#numbers.formatDecimal(p.probabilidad,1,1)}"></td>
                             <td th:text="${p.fecha}"></td>
                         </tr>
+                        <tr style="background-color:#f0f0f0;font-weight:bold;">
+                            <td colspan="3">
+                                Mínimo: <span th:text="${preMin}"></span> |
+                                Máximo: <span th:text="${preMax}"></span> |
+                                Promedio: <span th:text="${preAvg}"></span>
+                            </td>
+                        </tr>
                     </tbody>
                 </table>
             </div>
@@ -102,6 +116,13 @@
                             <td th:text="${h.id}"></td>
                             <td th:text="${h.humedad}"></td>
                             <td th:text="${h.fecha}"></td>
+                        </tr>
+                        <tr style="background-color:#f0f0f0;font-weight:bold;">
+                            <td colspan="3">
+                                Mínimo: <span th:text="${humMin}"></span> |
+                                Máximo: <span th:text="${humMax}"></span> |
+                                Promedio: <span th:text="${humAvg}"></span>
+                            </td>
                         </tr>
                     </tbody>
                 </table>
@@ -116,6 +137,13 @@
                             <td th:text="${t.temperatura}"></td>
                             <td th:text="${t.fecha}"></td>
                         </tr>
+                        <tr style="background-color:#f0f0f0;font-weight:bold;">
+                            <td colspan="3">
+                                Mínimo: <span th:text="${temMin}"></span> |
+                                Máximo: <span th:text="${temMax}"></span> |
+                                Promedio: <span th:text="${temAvg}"></span>
+                            </td>
+                        </tr>
                     </tbody>
                 </table>
             </div>
@@ -129,6 +157,13 @@
                             <td th:text="${p.presion}"></td>
                             <td th:text="${p.fecha}"></td>
                         </tr>
+                        <tr style="background-color:#f0f0f0;font-weight:bold;">
+                            <td colspan="3">
+                                Mínimo: <span th:text="${presMin}"></span> |
+                                Máximo: <span th:text="${presMax}"></span> |
+                                Promedio: <span th:text="${presAvg}"></span>
+                            </td>
+                        </tr>
                     </tbody>
                 </table>
             </div>
@@ -141,6 +176,13 @@
                             <td th:text="${hs.id}"></td>
                             <td th:text="${hs.humedad}"></td>
                             <td th:text="${hs.fecha}"></td>
+                        </tr>
+                        <tr style="background-color:#f0f0f0;font-weight:bold;">
+                            <td colspan="3">
+                                Mínimo: <span th:text="${humSMin}"></span> |
+                                Máximo: <span th:text="${humSMax}"></span> |
+                                Promedio: <span th:text="${humSAvg}"></span>
+                            </td>
                         </tr>
                     </tbody>
                 </table>

--- a/app/src/main/resources/templates/reportePreview.html
+++ b/app/src/main/resources/templates/reportePreview.html
@@ -68,7 +68,7 @@
                             <td colspan="3">
                                 Mínimo: <span th:text="${velMin}"></span> |
                                 Máximo: <span th:text="${velMax}"></span> |
-                                Promedio: <span th:text="${velAvg}"></span>
+                                Promedio: <span th:text="${velAvg != null ? #numbers.formatDecimal(velAvg, 1, 2) : ''}"></span>
                             </td>
                         </tr>
                     </tbody>
@@ -101,7 +101,7 @@
                             <td colspan="3">
                                 Mínimo: <span th:text="${preMin}"></span> |
                                 Máximo: <span th:text="${preMax}"></span> |
-                                Promedio: <span th:text="${preAvg}"></span>
+                                Promedio: <span th:text="${preAvg != null ? #numbers.formatDecimal(preAvg, 1, 2) : ''}"></span>
                             </td>
                         </tr>
                     </tbody>
@@ -121,7 +121,7 @@
                             <td colspan="3">
                                 Mínimo: <span th:text="${humMin}"></span> |
                                 Máximo: <span th:text="${humMax}"></span> |
-                                Promedio: <span th:text="${humAvg}"></span>
+                                Promedio: <span th:text="${humAvg != null ? #numbers.formatDecimal(humAvg, 1, 2) : ''}"></span>
                             </td>
                         </tr>
                     </tbody>
@@ -141,7 +141,7 @@
                             <td colspan="3">
                                 Mínimo: <span th:text="${temMin}"></span> |
                                 Máximo: <span th:text="${temMax}"></span> |
-                                Promedio: <span th:text="${temAvg}"></span>
+                                Promedio: <span th:text="${temAvg != null ? #numbers.formatDecimal(temAvg, 1, 2) : ''}"></span>
                             </td>
                         </tr>
                     </tbody>
@@ -161,7 +161,7 @@
                             <td colspan="3">
                                 Mínimo: <span th:text="${presMin}"></span> |
                                 Máximo: <span th:text="${presMax}"></span> |
-                                Promedio: <span th:text="${presAvg}"></span>
+                                Promedio: <span th:text="${presAvg != null ? #numbers.formatDecimal(presAvg, 1, 2) : ''}"></span>
                             </td>
                         </tr>
                     </tbody>
@@ -181,7 +181,7 @@
                             <td colspan="3">
                                 Mínimo: <span th:text="${humSMin}"></span> |
                                 Máximo: <span th:text="${humSMax}"></span> |
-                                Promedio: <span th:text="${humSAvg}"></span>
+                                Promedio: <span th:text="${humSAvg != null ? #numbers.formatDecimal(humSAvg, 1, 2) : ''}"></span>
                             </td>
                         </tr>
                     </tbody>

--- a/app/src/main/resources/templates/reportePreview.html
+++ b/app/src/main/resources/templates/reportePreview.html
@@ -84,6 +84,9 @@
                             <td th:text="${d.direccion}"></td>
                             <td th:text="${d.fecha}"></td>
                         </tr>
+                        <tr style="background-color:#f0f0f0;font-weight:bold;">
+                            <td colspan="3">Más frecuente: <span th:text="${dirFrecuente}"></span></td>
+                        </tr>
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
## Summary
- compute min, max and average for each data type when showing a report
- display a grey summary row with those values in `reportePreview.html`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68717e5070c483229f8766606735c754