### PR TITLE
Enable WebSocket updates for station summary

### DIFF
--- a/app/src/main/java/org/javadominicano/dto/ResumenEstadoEstacionesDTO.java
+++ b/app/src/main/java/org/javadominicano/dto/ResumenEstadoEstacionesDTO.java
@@ -1,0 +1,40 @@
+package org.javadominicano.dto;
+
+public class ResumenEstadoEstacionesDTO {
+    private long total;
+    private long activas;
+    private long inactivas;
+    private String primeraInactivaId;
+
+    public long getTotal() {
+        return total;
+    }
+
+    public void setTotal(long total) {
+        this.total = total;
+    }
+
+    public long getActivas() {
+        return activas;
+    }
+
+    public void setActivas(long activas) {
+        this.activas = activas;
+    }
+
+    public long getInactivas() {
+        return inactivas;
+    }
+
+    public void setInactivas(long inactivas) {
+        this.inactivas = inactivas;
+    }
+
+    public String getPrimeraInactivaId() {
+        return primeraInactivaId;
+    }
+
+    public void setPrimeraInactivaId(String primeraInactivaId) {
+        this.primeraInactivaId = primeraInactivaId;
+    }
+}

--- a/app/src/main/java/org/javadominicano/websocket/EstadoEstacionesBroadcastService.java
+++ b/app/src/main/java/org/javadominicano/websocket/EstadoEstacionesBroadcastService.java
@@ -1,0 +1,41 @@
+package org.javadominicano.websocket;
+
+import org.javadominicano.dto.EstadoEstacionDTO;
+import org.javadominicano.dto.ResumenEstadoEstacionesDTO;
+import org.javadominicano.servicios.EstadoEstacionesService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class EstadoEstacionesBroadcastService {
+    @Autowired
+    private SimpMessagingTemplate messagingTemplate;
+
+    @Autowired
+    private EstadoEstacionesService estadoService;
+
+    @Scheduled(fixedRate = 5000)
+    public void broadcastEstado() {
+        List<EstadoEstacionDTO> estados = estadoService.obtenerEstados();
+        long total = estados.size();
+        long activas = estados.stream().filter(EstadoEstacionDTO::isActiva).count();
+        long inactivas = total - activas;
+        Optional<String> primeraInactiva = estados.stream()
+                .filter(e -> !e.isActiva())
+                .map(EstadoEstacionDTO::getId)
+                .findFirst();
+
+        ResumenEstadoEstacionesDTO dto = new ResumenEstadoEstacionesDTO();
+        dto.setTotal(total);
+        dto.setActivas(activas);
+        dto.setInactivas(inactivas);
+        dto.setPrimeraInactivaId(primeraInactiva.orElse(null));
+
+        messagingTemplate.convertAndSend("/topic/estadoEstaciones", dto);
+    }
+}

--- a/app/src/main/resources/templates/dashboard.html
+++ b/app/src/main/resources/templates/dashboard.html
@@ -684,6 +684,16 @@ updateCharts();
             document.getElementById('pressValue').textContent = data.presion + ' hPa';
             document.getElementById('soilHumValue').textContent = data.humedadSuelo + '%';
         });
+
+        stomp.subscribe('/topic/estadoEstaciones', (msg) => {
+            const data = JSON.parse(msg.body);
+            const nums = document.querySelectorAll('.info-bar .section .number');
+            if (nums.length >= 3) {
+                nums[0].textContent = data.total;
+                nums[1].textContent = data.activas;
+                nums[2].textContent = data.inactivas;
+            }
+        });
     });
 </script>
 


### PR DESCRIPTION
## Summary
- stream station status counts over WebSocket
- add DTO for summary data
- update dashboard to update counts in real time

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687478753220832289a04afa1e8a9f39