### PR TITLE
Improve alert configuration form

### DIFF
--- a/app/src/main/java/org/javadominicano/controladores/VisualizadorController.java
+++ b/app/src/main/java/org/javadominicano/controladores/VisualizadorController.java
@@ -247,44 +247,52 @@ public class VisualizadorController {
     @PostMapping("/configurar-alertas")
     public String configurarAlertas(@ModelAttribute Umbrales umbrales,
                                     @RequestParam(required = false) Boolean chkTemp,
+                                    @RequestParam(required = false) String opTemp,
                                     @RequestParam(required = false) Boolean chkHum,
+                                    @RequestParam(required = false) String opHum,
                                     @RequestParam(required = false) Boolean chkVel,
+                                    @RequestParam(required = false) String opVel,
                                     @RequestParam(required = false) Boolean chkPre,
+                                    @RequestParam(required = false) String opPre,
                                     @RequestParam(required = false) Boolean chkPres,
+                                    @RequestParam(required = false) String opPres,
                                     @RequestParam(required = false) Boolean chkHumSu,
+                                    @RequestParam(required = false) String opHumSu,
+                                    @RequestParam String estacion,
                                     Model model) {
         if (Boolean.TRUE.equals(chkTemp)) {
-            guardarOActualizar("Temperatura", umbrales.getTemperatura());
+            guardarOActualizar("Temperatura", umbrales.getTemperatura(), opTemp, estacion);
         }
         if (Boolean.TRUE.equals(chkHum)) {
-            guardarOActualizar("Humedad", umbrales.getHumedad());
+            guardarOActualizar("Humedad", umbrales.getHumedad(), opHum, estacion);
         }
         if (Boolean.TRUE.equals(chkVel)) {
-            guardarOActualizar("VelocidadViento", umbrales.getVelocidadViento());
+            guardarOActualizar("VelocidadViento", umbrales.getVelocidadViento(), opVel, estacion);
         }
         if (Boolean.TRUE.equals(chkPre)) {
-            guardarOActualizar("Precipitacion", umbrales.getPrecipitacion());
+            guardarOActualizar("Precipitacion", umbrales.getPrecipitacion(), opPre, estacion);
         }
         if (Boolean.TRUE.equals(chkPres)) {
-            guardarOActualizar("Presion", umbrales.getPresion());
+            guardarOActualizar("Presion", umbrales.getPresion(), opPres, estacion);
         }
         if (Boolean.TRUE.equals(chkHumSu)) {
-            guardarOActualizar("HumedadSuelo", umbrales.getHumedadSuelo());
+            guardarOActualizar("HumedadSuelo", umbrales.getHumedadSuelo(), opHumSu, estacion);
         }
 
         return "redirect:/"; // Redirige al dashboard para que se recargue
     }
 
-    private void guardarOActualizar(String nombre, double umbral) {
-        Alerta a = repoAlerta.findByNombre(nombre);
+    private void guardarOActualizar(String nombre, double umbral, String operador, String estacionId) {
+        Alerta a = repoAlerta.findByNombreAndEstacionId(nombre, estacionId);
         if (a == null) {
             a = new Alerta();
             a.setNombre(nombre);
-            a.setOperador(">");
             a.setPrioridad("Media");
             a.setActiva(true);
         }
+        a.setOperador(operador);
         a.setUmbral(umbral);
+        a.setEstacionId(estacionId);
         repoAlerta.save(a);
     }
 

--- a/app/src/main/java/org/javadominicano/entidades/Alerta.java
+++ b/app/src/main/java/org/javadominicano/entidades/Alerta.java
@@ -21,6 +21,9 @@ public class Alerta {
 
     private String prioridad = "Media";
 
+    @Column(name = "estacion_id")
+    private String estacionId;
+
     @CreationTimestamp
     @Column(name = "fecha_creacion", updatable = false)
     private Timestamp fechaCreacion;
@@ -71,6 +74,14 @@ public class Alerta {
 
     public void setPrioridad(String prioridad) {
         this.prioridad = prioridad;
+    }
+
+    public String getEstacionId() {
+        return estacionId;
+    }
+
+    public void setEstacionId(String estacionId) {
+        this.estacionId = estacionId;
     }
 
     public Timestamp getFechaCreacion() {

--- a/app/src/main/java/org/javadominicano/repositorios/RepositorioAlerta.java
+++ b/app/src/main/java/org/javadominicano/repositorios/RepositorioAlerta.java
@@ -5,5 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RepositorioAlerta extends JpaRepository<Alerta, Long> {
     Alerta findByNombre(String nombre);
+    Alerta findByNombreAndEstacionId(String nombre, String estacionId);
     long countByActiva(boolean activa);
 }

--- a/app/src/main/resources/templates/alertas.html
+++ b/app/src/main/resources/templates/alertas.html
@@ -225,7 +225,11 @@
         <div class="threshold-card">
             <div class="title-row">
                 <input type="checkbox" id="chk-temp" name="chkTemp" checked />
-                <label for="temp">Temperatura &gt;</label>
+                <label for="temp">Temperatura</label>
+                <select name="opTemp">
+                    <option value=">">&gt;</option>
+                    <option value="<">&lt;</option>
+                </select>
             </div>
             <input id="temp" type="number" step="0.1" name="temperatura" th:value="${umbrales.temperatura}" required />
             <span>°C</span>
@@ -233,7 +237,11 @@
         <div class="threshold-card">
             <div class="title-row">
                 <input type="checkbox" id="chk-hum" name="chkHum" checked />
-                <label for="hum">Humedad &gt;</label>
+                <label for="hum">Humedad</label>
+                <select name="opHum">
+                    <option value=">">&gt;</option>
+                    <option value="<">&lt;</option>
+                </select>
             </div>
             <input id="hum" type="number" step="0.1" name="humedad" th:value="${umbrales.humedad}" required />
             <span>%</span>
@@ -241,7 +249,11 @@
         <div class="threshold-card">
             <div class="title-row">
                 <input type="checkbox" id="chk-vel" name="chkVel" checked />
-                <label for="vel">Vel. Viento &gt;</label>
+                <label for="vel">Vel. Viento</label>
+                <select name="opVel">
+                    <option value=">">&gt;</option>
+                    <option value="<">&lt;</option>
+                </select>
             </div>
             <input id="vel" type="number" step="0.1" name="velocidadViento" th:value="${umbrales.velocidadViento}" required />
             <span>km/h</span>
@@ -249,7 +261,11 @@
         <div class="threshold-card">
             <div class="title-row">
                 <input type="checkbox" id="chk-pre" name="chkPre" checked />
-                <label for="pre">Precipitación &gt;</label>
+                <label for="pre">Precipitación</label>
+                <select name="opPre">
+                    <option value=">">&gt;</option>
+                    <option value="<">&lt;</option>
+                </select>
             </div>
             <input id="pre" type="number" step="0.1" name="precipitacion" th:value="${umbrales.precipitacion}" required />
             <span>mm</span>
@@ -257,7 +273,11 @@
         <div class="threshold-card">
             <div class="title-row">
                 <input type="checkbox" id="chk-pres" name="chkPres" checked />
-                <label for="pres">Presión &gt;</label>
+                <label for="pres">Presión</label>
+                <select name="opPres">
+                    <option value=">">&gt;</option>
+                    <option value="<">&lt;</option>
+                </select>
             </div>
             <input id="pres" type="number" step="0.1" name="presion" th:value="${umbrales.presion}" required />
             <span>hPa</span>
@@ -265,12 +285,22 @@
         <div class="threshold-card">
             <div class="title-row">
                 <input type="checkbox" id="chk-humsu" name="chkHumSu" checked />
-                <label for="humsu">Humedad Suelo &gt;</label>
+                <label for="humsu">Humedad Suelo</label>
+                <select name="opHumSu">
+                    <option value=">">&gt;</option>
+                    <option value="<">&lt;</option>
+                </select>
             </div>
             <input id="humsu" type="number" step="0.1" name="humedadSuelo" th:value="${umbrales.humedadSuelo}" required />
             <span>%</span>
         </div>
         <button type="submit" class="btn btn-edit" style="align-self:flex-start;">Guardar</button>
+        <div style="margin-top:10px; width:100%;">
+            <label for="estacion" style="color:white;">Estación:</label>
+            <select id="estacion" name="estacion" style="margin-left:5px;">
+                <option th:each="e : ${estaciones}" th:value="${e.id}" th:text="${e.nombre}"></option>
+            </select>
+        </div>
     </form>
 
     <div class="active-alerts" th:if="${alertasActivas != null}">


### PR DESCRIPTION
## Summary
- allow choosing comparison operator and station when configuring alerts
- store selected station on alerts

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6879146630dc8322b1ed8345f07db12a