### PR TITLE
Improve alert threshold form with operator selector

### DIFF
--- a/app/bin/main/templates/alertas.html
+++ b/app/bin/main/templates/alertas.html
@@ -154,6 +154,14 @@
         }
         .threshold-card label { font-weight: bold; margin-bottom: 8px; color: white; }
         .threshold-card .title-row { display:flex; align-items:center; gap:6px; margin-bottom:8px; }
+        .threshold-card select {
+            padding: 4px;
+            border: 1px solid rgba(255,255,255,0.7);
+            border-radius: 4px;
+            background: rgba(255,255,255,0.1);
+            color: white;
+        }
+        .threshold-card option { color: black; }
         .threshold-card input[type="number"] {
             padding: 6px;
             border: 1px solid rgba(255,255,255,0.7);
@@ -225,7 +233,11 @@
         <div class="threshold-card">
             <div class="title-row">
                 <input type="checkbox" id="chk-temp" name="chkTemp" checked />
-                <label for="temp">Temperatura &gt;</label>
+                <label for="temp">Temperatura</label>
+                <select name="opTemp">
+                    <option value="&gt;">&gt;</option>
+                    <option value="&lt;">&lt;</option>
+                </select>
             </div>
             <input id="temp" type="number" step="0.1" name="temperatura" th:value="${umbrales.temperatura}" required />
             <span>°C</span>
@@ -233,7 +245,11 @@
         <div class="threshold-card">
             <div class="title-row">
                 <input type="checkbox" id="chk-hum" name="chkHum" checked />
-                <label for="hum">Humedad &gt;</label>
+                <label for="hum">Humedad</label>
+                <select name="opHum">
+                    <option value="&gt;">&gt;</option>
+                    <option value="&lt;">&lt;</option>
+                </select>
             </div>
             <input id="hum" type="number" step="0.1" name="humedad" th:value="${umbrales.humedad}" required />
             <span>%</span>
@@ -241,7 +257,11 @@
         <div class="threshold-card">
             <div class="title-row">
                 <input type="checkbox" id="chk-vel" name="chkVel" checked />
-                <label for="vel">Vel. Viento &gt;</label>
+                <label for="vel">Vel. Viento</label>
+                <select name="opVel">
+                    <option value="&gt;">&gt;</option>
+                    <option value="&lt;">&lt;</option>
+                </select>
             </div>
             <input id="vel" type="number" step="0.1" name="velocidadViento" th:value="${umbrales.velocidadViento}" required />
             <span>km/h</span>
@@ -249,7 +269,11 @@
         <div class="threshold-card">
             <div class="title-row">
                 <input type="checkbox" id="chk-pre" name="chkPre" checked />
-                <label for="pre">Precipitación &gt;</label>
+                <label for="pre">Precipitación</label>
+                <select name="opPre">
+                    <option value="&gt;">&gt;</option>
+                    <option value="&lt;">&lt;</option>
+                </select>
             </div>
             <input id="pre" type="number" step="0.1" name="precipitacion" th:value="${umbrales.precipitacion}" required />
             <span>mm</span>
@@ -257,7 +281,11 @@
         <div class="threshold-card">
             <div class="title-row">
                 <input type="checkbox" id="chk-pres" name="chkPres" checked />
-                <label for="pres">Presión &gt;</label>
+                <label for="pres">Presión</label>
+                <select name="opPres">
+                    <option value="&gt;">&gt;</option>
+                    <option value="&lt;">&lt;</option>
+                </select>
             </div>
             <input id="pres" type="number" step="0.1" name="presion" th:value="${umbrales.presion}" required />
             <span>hPa</span>
@@ -265,7 +293,11 @@
         <div class="threshold-card">
             <div class="title-row">
                 <input type="checkbox" id="chk-humsu" name="chkHumSu" checked />
-                <label for="humsu">Humedad Suelo &gt;</label>
+                <label for="humsu">Humedad Suelo</label>
+                <select name="opHumSu">
+                    <option value="&gt;">&gt;</option>
+                    <option value="&lt;">&lt;</option>
+                </select>
             </div>
             <input id="humsu" type="number" step="0.1" name="humedadSuelo" th:value="${umbrales.humedadSuelo}" required />
             <span>%</span>

--- a/app/src/main/java/org/javadominicano/controladores/VisualizadorController.java
+++ b/app/src/main/java/org/javadominicano/controladores/VisualizadorController.java
@@ -252,38 +252,44 @@ public class VisualizadorController {
                                     @RequestParam(required = false) Boolean chkPre,
                                     @RequestParam(required = false) Boolean chkPres,
                                     @RequestParam(required = false) Boolean chkHumSu,
+                                    @RequestParam String opTemp,
+                                    @RequestParam String opHum,
+                                    @RequestParam String opVel,
+                                    @RequestParam String opPre,
+                                    @RequestParam String opPres,
+                                    @RequestParam String opHumSu,
                                     Model model) {
         if (Boolean.TRUE.equals(chkTemp)) {
-            guardarOActualizar("Temperatura", umbrales.getTemperatura());
+            guardarOActualizar("Temperatura", umbrales.getTemperatura(), opTemp);
         }
         if (Boolean.TRUE.equals(chkHum)) {
-            guardarOActualizar("Humedad", umbrales.getHumedad());
+            guardarOActualizar("Humedad", umbrales.getHumedad(), opHum);
         }
         if (Boolean.TRUE.equals(chkVel)) {
-            guardarOActualizar("VelocidadViento", umbrales.getVelocidadViento());
+            guardarOActualizar("VelocidadViento", umbrales.getVelocidadViento(), opVel);
         }
         if (Boolean.TRUE.equals(chkPre)) {
-            guardarOActualizar("Precipitacion", umbrales.getPrecipitacion());
+            guardarOActualizar("Precipitacion", umbrales.getPrecipitacion(), opPre);
         }
         if (Boolean.TRUE.equals(chkPres)) {
-            guardarOActualizar("Presion", umbrales.getPresion());
+            guardarOActualizar("Presion", umbrales.getPresion(), opPres);
         }
         if (Boolean.TRUE.equals(chkHumSu)) {
-            guardarOActualizar("HumedadSuelo", umbrales.getHumedadSuelo());
+            guardarOActualizar("HumedadSuelo", umbrales.getHumedadSuelo(), opHumSu);
         }
 
         return "redirect:/"; // Redirige al dashboard para que se recargue
     }
 
-    private void guardarOActualizar(String nombre, double umbral) {
+    private void guardarOActualizar(String nombre, double umbral, String operador) {
         Alerta a = repoAlerta.findByNombre(nombre);
         if (a == null) {
             a = new Alerta();
             a.setNombre(nombre);
-            a.setOperador(">");
             a.setPrioridad("Media");
             a.setActiva(true);
         }
+        a.setOperador(operador);
         a.setUmbral(umbral);
         repoAlerta.save(a);
     }

--- a/app/src/main/resources/templates/alertas.html
+++ b/app/src/main/resources/templates/alertas.html
@@ -154,6 +154,14 @@
         }
         .threshold-card label { font-weight: bold; margin-bottom: 8px; color: white; }
         .threshold-card .title-row { display:flex; align-items:center; gap:6px; margin-bottom:8px; }
+        .threshold-card select {
+            padding: 4px;
+            border: 1px solid rgba(255,255,255,0.7);
+            border-radius: 4px;
+            background: rgba(255,255,255,0.1);
+            color: white;
+        }
+        .threshold-card option { color: black; }
         .threshold-card input[type="number"] {
             padding: 6px;
             border: 1px solid rgba(255,255,255,0.7);
@@ -225,7 +233,11 @@
         <div class="threshold-card">
             <div class="title-row">
                 <input type="checkbox" id="chk-temp" name="chkTemp" checked />
-                <label for="temp">Temperatura &gt;</label>
+                <label for="temp">Temperatura</label>
+                <select name="opTemp">
+                    <option value="&gt;">&gt;</option>
+                    <option value="&lt;">&lt;</option>
+                </select>
             </div>
             <input id="temp" type="number" step="0.1" name="temperatura" th:value="${umbrales.temperatura}" required />
             <span>°C</span>
@@ -233,7 +245,11 @@
         <div class="threshold-card">
             <div class="title-row">
                 <input type="checkbox" id="chk-hum" name="chkHum" checked />
-                <label for="hum">Humedad &gt;</label>
+                <label for="hum">Humedad</label>
+                <select name="opHum">
+                    <option value="&gt;">&gt;</option>
+                    <option value="&lt;">&lt;</option>
+                </select>
             </div>
             <input id="hum" type="number" step="0.1" name="humedad" th:value="${umbrales.humedad}" required />
             <span>%</span>
@@ -241,7 +257,11 @@
         <div class="threshold-card">
             <div class="title-row">
                 <input type="checkbox" id="chk-vel" name="chkVel" checked />
-                <label for="vel">Vel. Viento &gt;</label>
+                <label for="vel">Vel. Viento</label>
+                <select name="opVel">
+                    <option value="&gt;">&gt;</option>
+                    <option value="&lt;">&lt;</option>
+                </select>
             </div>
             <input id="vel" type="number" step="0.1" name="velocidadViento" th:value="${umbrales.velocidadViento}" required />
             <span>km/h</span>
@@ -249,7 +269,11 @@
         <div class="threshold-card">
             <div class="title-row">
                 <input type="checkbox" id="chk-pre" name="chkPre" checked />
-                <label for="pre">Precipitación &gt;</label>
+                <label for="pre">Precipitación</label>
+                <select name="opPre">
+                    <option value="&gt;">&gt;</option>
+                    <option value="&lt;">&lt;</option>
+                </select>
             </div>
             <input id="pre" type="number" step="0.1" name="precipitacion" th:value="${umbrales.precipitacion}" required />
             <span>mm</span>
@@ -257,7 +281,11 @@
         <div class="threshold-card">
             <div class="title-row">
                 <input type="checkbox" id="chk-pres" name="chkPres" checked />
-                <label for="pres">Presión &gt;</label>
+                <label for="pres">Presión</label>
+                <select name="opPres">
+                    <option value="&gt;">&gt;</option>
+                    <option value="&lt;">&lt;</option>
+                </select>
             </div>
             <input id="pres" type="number" step="0.1" name="presion" th:value="${umbrales.presion}" required />
             <span>hPa</span>
@@ -265,7 +293,11 @@
         <div class="threshold-card">
             <div class="title-row">
                 <input type="checkbox" id="chk-humsu" name="chkHumSu" checked />
-                <label for="humsu">Humedad Suelo &gt;</label>
+                <label for="humsu">Humedad Suelo</label>
+                <select name="opHumSu">
+                    <option value="&gt;">&gt;</option>
+                    <option value="&lt;">&lt;</option>
+                </select>
             </div>
             <input id="humsu" type="number" step="0.1" name="humedadSuelo" th:value="${umbrales.humedadSuelo}" required />
             <span>%</span>


### PR DESCRIPTION
## Summary
- redesign threshold cards with operator dropdowns
- add styles for dropdowns
- pass selected operator values to backend
- persist operators when configuring alerts

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687916a0b0148322bd557bbcfcb89d62