### PR TITLE
Fix alerts state refresh

### DIFF
--- a/app/src/main/java/org/servicios/AlertasService.java
+++ b/app/src/main/java/org/servicios/AlertasService.java
@@ -86,13 +86,21 @@ public class AlertasService {
             alertasDisparadas.remove(alerta.getId());
         }
 
-        if (chequearAlerta(alerta, valor) && !alertasDisparadas.contains(alerta.getId())) {
+        boolean activa = chequearAlerta(alerta, valor);
+        if (activa) {
             AlertaActivaDTO dto = new AlertaActivaDTO();
             dto.setAlerta(alerta);
             dto.setValorActual(valor);
             dto.setFecha(fecha);
             lista.add(dto);
-            alertasDisparadas.add(alerta.getId());
+
+            // Solo marcar como disparada la primera vez que se detecta
+            if (!alertasDisparadas.contains(alerta.getId())) {
+                alertasDisparadas.add(alerta.getId());
+            }
+        } else {
+            // Si deja de estar activa, permitir que vuelva a dispararse
+            alertasDisparadas.remove(alerta.getId());
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure alert remains in active list while condition holds
- allow alerts to be triggered again after clearing

## Testing
- `./gradlew test` *(fails: HTTP 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68791a97befc8322b38371eff97cb0fa