### PR TITLE
Add station selection to alerts

### DIFF
--- a/app/src/main/java/org/javadominicano/controladores/AlertasController.java
+++ b/app/src/main/java/org/javadominicano/controladores/AlertasController.java
@@ -4,6 +4,8 @@ import org.javadominicano.entidades.Alerta;
 import org.javadominicano.repositorios.RepositorioAlerta;
 import org.javadominicano.repositorios.RepositorioDatosPrecipitacion;
 import org.javadominicano.repositorios.RepositorioDatosVelocidad;
+import org.javadominicano.entidades.EstacionMeteorologica;
+import org.javadominicano.repositorios.RepositorioEstacionMeteorologica;
 import org.javadominicano.visualizadorweb.repositorios.RepositorioDatosHumedad;
 import org.javadominicano.visualizadorweb.repositorios.RepositorioDatosTemperatura;
 import org.javadominicano.visualizadorweb.entidades.Umbrales;
@@ -45,6 +47,9 @@ public class AlertasController {
     private RepositorioDatosPrecipitacion repoPrecipitacion;
 
     @Autowired
+    private RepositorioEstacionMeteorologica repoEstacion;
+
+    @Autowired
     private AlertasService alertasService;
 
     @ModelAttribute("umbrales")
@@ -64,6 +69,11 @@ public class AlertasController {
         umbrales.setPresion(pres != null ? pres.getUmbral() : 1013.0);
         umbrales.setHumedadSuelo(humSu != null ? humSu.getUmbral() : 40.0);
         return umbrales;
+    }
+
+    @ModelAttribute("estaciones")
+    public List<EstacionMeteorologica> getEstaciones() {
+        return repoEstacion.findAll();
     }
 
     @GetMapping("/alertas")

--- a/app/src/main/java/org/javadominicano/controladores/VisualizadorController.java
+++ b/app/src/main/java/org/javadominicano/controladores/VisualizadorController.java
@@ -246,6 +246,7 @@ public class VisualizadorController {
 
     @PostMapping("/configurar-alertas")
     public String configurarAlertas(@ModelAttribute Umbrales umbrales,
+                                    @RequestParam String estacion,
                                     @RequestParam(required = false) Boolean chkTemp,
                                     @RequestParam(required = false) Boolean chkHum,
                                     @RequestParam(required = false) Boolean chkVel,
@@ -254,37 +255,39 @@ public class VisualizadorController {
                                     @RequestParam(required = false) Boolean chkHumSu,
                                     Model model) {
         if (Boolean.TRUE.equals(chkTemp)) {
-            guardarOActualizar("Temperatura", umbrales.getTemperatura());
+            guardarOActualizar("Temperatura", umbrales.getTemperatura(), estacion);
         }
         if (Boolean.TRUE.equals(chkHum)) {
-            guardarOActualizar("Humedad", umbrales.getHumedad());
+            guardarOActualizar("Humedad", umbrales.getHumedad(), estacion);
         }
         if (Boolean.TRUE.equals(chkVel)) {
-            guardarOActualizar("VelocidadViento", umbrales.getVelocidadViento());
+            guardarOActualizar("VelocidadViento", umbrales.getVelocidadViento(), estacion);
         }
         if (Boolean.TRUE.equals(chkPre)) {
-            guardarOActualizar("Precipitacion", umbrales.getPrecipitacion());
+            guardarOActualizar("Precipitacion", umbrales.getPrecipitacion(), estacion);
         }
         if (Boolean.TRUE.equals(chkPres)) {
-            guardarOActualizar("Presion", umbrales.getPresion());
+            guardarOActualizar("Presion", umbrales.getPresion(), estacion);
         }
         if (Boolean.TRUE.equals(chkHumSu)) {
-            guardarOActualizar("HumedadSuelo", umbrales.getHumedadSuelo());
+            guardarOActualizar("HumedadSuelo", umbrales.getHumedadSuelo(), estacion);
         }
 
         return "redirect:/"; // Redirige al dashboard para que se recargue
     }
 
-    private void guardarOActualizar(String nombre, double umbral) {
-        Alerta a = repoAlerta.findByNombre(nombre);
+    private void guardarOActualizar(String nombre, double umbral, String estacionId) {
+        Alerta a = repoAlerta.findByNombreAndEstacionId(nombre, estacionId);
         if (a == null) {
             a = new Alerta();
             a.setNombre(nombre);
+            a.setEstacionId(estacionId);
             a.setOperador(">");
             a.setPrioridad("Media");
             a.setActiva(true);
         }
         a.setUmbral(umbral);
+        a.setEstacionId(estacionId);
         repoAlerta.save(a);
     }
 

--- a/app/src/main/java/org/javadominicano/entidades/Alerta.java
+++ b/app/src/main/java/org/javadominicano/entidades/Alerta.java
@@ -21,6 +21,9 @@ public class Alerta {
 
     private String prioridad = "Media";
 
+    @Column(name = "estacion_id")
+    private String estacionId;
+
     @CreationTimestamp
     @Column(name = "fecha_creacion", updatable = false)
     private Timestamp fechaCreacion;
@@ -71,6 +74,14 @@ public class Alerta {
 
     public void setPrioridad(String prioridad) {
         this.prioridad = prioridad;
+    }
+
+    public String getEstacionId() {
+        return estacionId;
+    }
+
+    public void setEstacionId(String estacionId) {
+        this.estacionId = estacionId;
     }
 
     public Timestamp getFechaCreacion() {

--- a/app/src/main/java/org/javadominicano/repositorios/RepositorioAlerta.java
+++ b/app/src/main/java/org/javadominicano/repositorios/RepositorioAlerta.java
@@ -4,6 +4,7 @@ import org.javadominicano.entidades.Alerta;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RepositorioAlerta extends JpaRepository<Alerta, Long> {
-    Alerta findByNombre(String nombre);
+    Alerta findByNombreAndEstacionId(String nombre, String estacionId);
+    Alerta findByNombre(String nombre); // compatible con código existente
     long countByActiva(boolean activa);
 }

--- a/app/src/main/java/org/javadominicano/repositorios/RepositorioDatosDireccion.java
+++ b/app/src/main/java/org/javadominicano/repositorios/RepositorioDatosDireccion.java
@@ -23,6 +23,9 @@ public interface RepositorioDatosDireccion extends JpaRepository<DatosDireccion,
     @Query("SELECT d FROM DatosDireccion d ORDER BY d.fecha DESC")
     List<DatosDireccion> findTopByOrderByFechaDesc(Pageable pageable);
 
+    @Query("SELECT d FROM DatosDireccion d WHERE d.estacionId = :estacionId ORDER BY d.fecha DESC")
+    List<DatosDireccion> findTopByEstacionIdOrderByFechaDesc(@Param("estacionId") String estacionId, Pageable pageable);
+
     @Query("SELECT MAX(d.fecha) FROM DatosDireccion d WHERE d.estacionId = :estacionId")
     Timestamp findUltimaFechaByEstacion(@Param("estacionId") String estacionId);
 }

--- a/app/src/main/java/org/javadominicano/repositorios/RepositorioDatosHumedad.java
+++ b/app/src/main/java/org/javadominicano/repositorios/RepositorioDatosHumedad.java
@@ -23,6 +23,9 @@ public interface RepositorioDatosHumedad extends JpaRepository<DatosHumedad, Int
     @Query("SELECT d FROM DatosHumedad d ORDER BY d.fecha DESC")
     List<DatosHumedad> findTopByOrderByFechaDesc(Pageable pageable);
 
+    @Query("SELECT d FROM DatosHumedad d WHERE d.estacionId = :estacionId ORDER BY d.fecha DESC")
+    List<DatosHumedad> findTopByEstacionIdOrderByFechaDesc(@Param("estacionId") String estacionId, Pageable pageable);
+
     @Query("SELECT MAX(d.fecha) FROM DatosHumedad d WHERE d.estacionId = :estacionId")
     Timestamp findUltimaFechaByEstacion(@Param("estacionId") String estacionId);
 }

--- a/app/src/main/java/org/javadominicano/repositorios/RepositorioDatosHumedadSuelo.java
+++ b/app/src/main/java/org/javadominicano/repositorios/RepositorioDatosHumedadSuelo.java
@@ -20,6 +20,9 @@ public interface RepositorioDatosHumedadSuelo extends JpaRepository<DatosHumedad
     @Query("SELECT d FROM DatosHumedadSuelo d ORDER BY d.fecha DESC")
     List<DatosHumedadSuelo> findTopByOrderByFechaDesc(Pageable pageable);
 
+    @Query("SELECT d FROM DatosHumedadSuelo d WHERE d.estacionId = :estacionId ORDER BY d.fecha DESC")
+    List<DatosHumedadSuelo> findTopByEstacionIdOrderByFechaDesc(@Param("estacionId") String estacionId, Pageable pageable);
+
     @Query("SELECT MAX(d.fecha) FROM DatosHumedadSuelo d WHERE d.estacionId = :estacionId")
     Timestamp findUltimaFechaByEstacion(@Param("estacionId") String estacionId);
 }

--- a/app/src/main/java/org/javadominicano/repositorios/RepositorioDatosPrecipitacion.java
+++ b/app/src/main/java/org/javadominicano/repositorios/RepositorioDatosPrecipitacion.java
@@ -25,6 +25,9 @@ public interface RepositorioDatosPrecipitacion extends JpaRepository<DatosPrecip
     @Query("SELECT d FROM DatosPrecipitacion d ORDER BY d.fecha DESC")
     List<DatosPrecipitacion> findTopByOrderByFechaDesc(Pageable pageable);
 
+    @Query("SELECT d FROM DatosPrecipitacion d WHERE d.estacionId = :estacionId ORDER BY d.fecha DESC")
+    List<DatosPrecipitacion> findTopByEstacionIdOrderByFechaDesc(@Param("estacionId") String estacionId, Pageable pageable);
+
     @Query("SELECT MAX(d.fecha) FROM DatosPrecipitacion d WHERE d.estacionId = :estacionId")
     Timestamp findUltimaFechaByEstacion(@Param("estacionId") String estacionId);
 }

--- a/app/src/main/java/org/javadominicano/repositorios/RepositorioDatosPresion.java
+++ b/app/src/main/java/org/javadominicano/repositorios/RepositorioDatosPresion.java
@@ -20,6 +20,9 @@ public interface RepositorioDatosPresion extends JpaRepository<DatosPresion, Int
     @Query("SELECT d FROM DatosPresion d ORDER BY d.fecha DESC")
     List<DatosPresion> findTopByOrderByFechaDesc(Pageable pageable);
 
+    @Query("SELECT d FROM DatosPresion d WHERE d.estacionId = :estacionId ORDER BY d.fecha DESC")
+    List<DatosPresion> findTopByEstacionIdOrderByFechaDesc(@Param("estacionId") String estacionId, Pageable pageable);
+
     @Query("SELECT MAX(d.fecha) FROM DatosPresion d WHERE d.estacionId = :estacionId")
     Timestamp findUltimaFechaByEstacion(@Param("estacionId") String estacionId);
 }

--- a/app/src/main/java/org/javadominicano/repositorios/RepositorioDatosTemperatura.java
+++ b/app/src/main/java/org/javadominicano/repositorios/RepositorioDatosTemperatura.java
@@ -23,6 +23,9 @@ public interface RepositorioDatosTemperatura extends JpaRepository<DatosTemperat
     @Query("SELECT d FROM DatosTemperatura d ORDER BY d.fecha DESC")
     List<DatosTemperatura> findTopByOrderByFechaDesc(Pageable pageable);
 
+    @Query("SELECT d FROM DatosTemperatura d WHERE d.estacionId = :estacionId ORDER BY d.fecha DESC")
+    List<DatosTemperatura> findTopByEstacionIdOrderByFechaDesc(@Param("estacionId") String estacionId, Pageable pageable);
+
     @Query("SELECT MAX(d.fecha) FROM DatosTemperatura d WHERE d.estacionId = :estacionId")
     Timestamp findUltimaFechaByEstacion(@Param("estacionId") String estacionId);
 }

--- a/app/src/main/java/org/javadominicano/repositorios/RepositorioDatosVelocidad.java
+++ b/app/src/main/java/org/javadominicano/repositorios/RepositorioDatosVelocidad.java
@@ -23,6 +23,9 @@ public interface RepositorioDatosVelocidad extends JpaRepository<DatosVelocidad,
     @Query("SELECT d FROM DatosVelocidad d ORDER BY d.fecha DESC")
     List<DatosVelocidad> findTopByOrderByFechaDesc(Pageable pageable);
 
+    @Query("SELECT d FROM DatosVelocidad d WHERE d.estacionId = :estacionId ORDER BY d.fecha DESC")
+    List<DatosVelocidad> findTopByEstacionIdOrderByFechaDesc(@Param("estacionId") String estacionId, Pageable pageable);
+
     // NUEVO MÉTODO: obtener la última fecha por cada sensor
     @Query("SELECT d.sensorId, MAX(d.fecha) FROM DatosVelocidad d GROUP BY d.sensorId")
     List<Object[]> findLastFechaBySensor();

--- a/app/src/main/java/org/servicios/AlertasService.java
+++ b/app/src/main/java/org/servicios/AlertasService.java
@@ -50,19 +50,68 @@ public class AlertasService {
     public List<AlertaActivaDTO> obtenerAlertasActivas() {
         List<AlertaActivaDTO> lista = new ArrayList<>();
 
-        DatosTemperatura temp = repoTemperatura.findTopByOrderByFechaDesc(PageRequest.of(0, 1)).get(0);
-        DatosHumedad hum      = repoHumedad.findTopByOrderByFechaDesc(PageRequest.of(0, 1)).get(0);
-        DatosVelocidad vel    = repoVelocidad.findTopByOrderByFechaDesc(PageRequest.of(0, 1)).get(0);
-        DatosPrecipitacion pre= repoPrecipitacion.findTopByOrderByFechaDesc(PageRequest.of(0, 1)).get(0);
-        DatosPresion pres      = repoPresion.findTopByOrderByFechaDesc(PageRequest.of(0,1)).get(0);
-        DatosHumedadSuelo hs   = repoHumedadSuelo.findTopByOrderByFechaDesc(PageRequest.of(0,1)).get(0);
+        List<Alerta> alertas = repoAlerta.findAll();
+        PageRequest pr = PageRequest.of(0, 1);
 
-        agregarAlertaActiva(lista, repoAlerta.findByNombre("Temperatura"), temp.getTemperatura(), temp.getFecha());
-        agregarAlertaActiva(lista, repoAlerta.findByNombre("Humedad"), hum.getHumedad(), hum.getFecha());
-        agregarAlertaActiva(lista, repoAlerta.findByNombre("VelocidadViento"), vel.getVelocidad(), vel.getFecha());
-        agregarAlertaActiva(lista, repoAlerta.findByNombre("Precipitacion"), pre.getProbabilidad(), pre.getFecha());
-        agregarAlertaActiva(lista, repoAlerta.findByNombre("Presion"), pres.getPresion(), pres.getFecha());
-        agregarAlertaActiva(lista, repoAlerta.findByNombre("HumedadSuelo"), hs.getHumedad(), hs.getFecha());
+        for (Alerta alerta : alertas) {
+            Timestamp fecha = null;
+            double valor = 0.0;
+
+            switch (alerta.getNombre()) {
+                case "Temperatura":
+                    List<DatosTemperatura> temps = repoTemperatura.findTopByEstacionIdOrderByFechaDesc(alerta.getEstacionId(), pr);
+                    if (!temps.isEmpty()) {
+                        DatosTemperatura t = temps.get(0);
+                        valor = t.getTemperatura();
+                        fecha = t.getFecha();
+                    }
+                    break;
+                case "Humedad":
+                    List<DatosHumedad> hums = repoHumedad.findTopByEstacionIdOrderByFechaDesc(alerta.getEstacionId(), pr);
+                    if (!hums.isEmpty()) {
+                        DatosHumedad h = hums.get(0);
+                        valor = h.getHumedad();
+                        fecha = h.getFecha();
+                    }
+                    break;
+                case "VelocidadViento":
+                    List<DatosVelocidad> vels = repoVelocidad.findTopByEstacionIdOrderByFechaDesc(alerta.getEstacionId(), pr);
+                    if (!vels.isEmpty()) {
+                        DatosVelocidad v = vels.get(0);
+                        valor = v.getVelocidad();
+                        fecha = v.getFecha();
+                    }
+                    break;
+                case "Precipitacion":
+                    List<DatosPrecipitacion> pres = repoPrecipitacion.findTopByEstacionIdOrderByFechaDesc(alerta.getEstacionId(), pr);
+                    if (!pres.isEmpty()) {
+                        DatosPrecipitacion p = pres.get(0);
+                        valor = p.getProbabilidad();
+                        fecha = p.getFecha();
+                    }
+                    break;
+                case "Presion":
+                    List<DatosPresion> press = repoPresion.findTopByEstacionIdOrderByFechaDesc(alerta.getEstacionId(), pr);
+                    if (!press.isEmpty()) {
+                        DatosPresion p = press.get(0);
+                        valor = p.getPresion();
+                        fecha = p.getFecha();
+                    }
+                    break;
+                case "HumedadSuelo":
+                    List<DatosHumedadSuelo> hs = repoHumedadSuelo.findTopByEstacionIdOrderByFechaDesc(alerta.getEstacionId(), pr);
+                    if (!hs.isEmpty()) {
+                        DatosHumedadSuelo s = hs.get(0);
+                        valor = s.getHumedad();
+                        fecha = s.getFecha();
+                    }
+                    break;
+            }
+
+            if (fecha != null) {
+                agregarAlertaActiva(lista, alerta, valor, fecha);
+            }
+        }
 
         return lista;
     }

--- a/app/src/main/resources/templates/alertas.html
+++ b/app/src/main/resources/templates/alertas.html
@@ -156,6 +156,20 @@
         .threshold-card input[type="checkbox"] { width:auto; margin:0; }
         .threshold-card span { margin-top: 4px; color: white; }
 
+        .estacion-field {
+            margin-top: 10px;
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            width: 200px;
+        }
+
+        .estacion-field select {
+            padding: 8px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+        }
+
         /* Barra resumen de alertas */
         .summary-bar {
             display: flex;
@@ -280,6 +294,12 @@
             </label>
         </div>
         <button type="submit" class="btn btn-edit" style="align-self:flex-start;">Guardar</button>
+        <div class="estacion-field">
+            <label for="estacion">Seleccionar estación:</label>
+            <select id="estacion" name="estacion">
+                <option th:each="est : ${estaciones}" th:value="${est.id}" th:text="${est.nombre}"></option>
+            </select>
+        </div>
     </form>
 
     <div class="configured-alerts" th:if="${alertas != null}">


### PR DESCRIPTION
## Summary
- add `estacionId` to `Alerta` entity
- allow saving alerts per station in `VisualizadorController`
- adjust `AlertasService` to evaluate alerts per station
- add repository methods for latest measurements by station
- show a station selector under the **Guardar** button
- style selector to match layout

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68793863a22c8322a6b721e0151653a4