### PR TITLE
Fix station 1 location display

### DIFF
--- a/app/src/main/java/org/javadominicano/entidades/EstacionMeteorologica.java
+++ b/app/src/main/java/org/javadominicano/entidades/EstacionMeteorologica.java
@@ -45,6 +45,10 @@ public class EstacionMeteorologica {
     }
 
     public String getUbicacion() {
+        if ((ubicacion == null || ubicacion.isBlank() || "Desconocida".equalsIgnoreCase(ubicacion))
+                && "1".equals(this.id)) {
+            return "Santiago";
+        }
         return ubicacion;
     }
     public void setUbicacion(String ubicacion) {


### PR DESCRIPTION
## Summary
- if station 1 has unknown or blank location, show "Santiago" as a default

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68796167eb9c8322bee9cf26e1e6aa41