### PR TITLE
Add help tooltip for report actions

### DIFF
--- a/app/src/main/resources/templates/reportes.html
+++ b/app/src/main/resources/templates/reportes.html
@@ -32,6 +32,30 @@
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
             max-width: 500px;
             margin-bottom: 30px;
+            position: relative;
+        }
+        .help-icon {
+            position: absolute;
+            top: 10px;
+            right: 10px;
+            cursor: pointer;
+            font-size: 18px;
+        }
+        .help-tooltip {
+            display: none;
+            position: absolute;
+            top: 35px;
+            right: 10px;
+            background: #f9f9f9;
+            color: #333;
+            border: 1px solid #ccc;
+            border-radius: 5px;
+            padding: 10px;
+            width: 220px;
+            z-index: 10;
+        }
+        .help-tooltip.show {
+            display: block;
         }
         .report-generator form {
             display: grid;
@@ -112,6 +136,12 @@
         <p class="subtitle">Generación de reportes y análisis</p>
 
         <div class="report-generator">
+            <span class="help-icon" id="helpIcon">❓</span>
+            <div class="help-tooltip" id="helpTooltip">
+                <p><strong>Limpiar Historial:</strong> Elimina todos los reportes generados anteriormente.</p>
+                <p><strong>Ver Actividad:</strong> Muestra las actividades registradas para la estación y fecha seleccionadas.</p>
+                <p><strong>Generar Reporte:</strong> Crea un reporte meteorológico con los filtros seleccionados.</p>
+            </div>
             <form method="post" th:action="@{/reportes}">
                 <div class="field">
                     <label for="fecha">Fecha:</label>
@@ -162,5 +192,14 @@
             </div>
         </div>
     </div>
+<script>
+    const helpIcon = document.getElementById('helpIcon');
+    const helpTooltip = document.getElementById('helpTooltip');
+    if (helpIcon) {
+        helpIcon.addEventListener('click', () => {
+            helpTooltip.classList.toggle('show');
+        });
+    }
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show an info button within the report generator box
- provide tooltip text for the report action buttons
- toggle tooltip visibility with a small script

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68796436e8208322b748ea9aec6f8ce2