### PR TITLE
Change date format for wind speed table

### DIFF
--- a/app/src/main/resources/templates/tablas.html
+++ b/app/src/main/resources/templates/tablas.html
@@ -71,7 +71,7 @@
               <td th:text="${v.id}"></td>
               <td th:text="${v.estacionId}"></td>
               <td th:text="${v.velocidad}"></td>
-              <td th:text="${v.fecha}"></td>
+              <td th:text="${#dates.format(v.fecha, 'dd/MM/yyyy HH:mm:ss')}"></td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
## Summary
- show wind speed record dates in the format `dd/MM/yyyy HH:mm:ss`

## Testing
- `./gradlew test --no-daemon` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687fef8f7d808322851341f90889e60c