### PR TITLE
Fix login page CSRF token

### DIFF
--- a/app/src/main/resources/templates/actividad.html
+++ b/app/src/main/resources/templates/actividad.html
@@ -54,6 +54,7 @@
             </ul>
         </nav>
         <form class="logout-form" th:action="@{/logout}" method="post">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
             <button type="submit">Cerrar sesión</button>
         </form>
     </div>

--- a/app/src/main/resources/templates/alertas.html
+++ b/app/src/main/resources/templates/alertas.html
@@ -296,6 +296,7 @@
         </ul>
     </nav>
     <form class="logout-form" th:action="@{/logout}" method="post">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
         <button type="submit">Cerrar sesión</button>
     </form>
 </div>
@@ -311,6 +312,7 @@
         <div class="configured-alerts-header">
             <h2>Alertas Configuradas (<span th:text="${alertas.size()}"></span>)</h2>
             <form th:action="@{/alertas/eliminar-configuradas}" method="post">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <button type="submit" class="btn-delete-all">Eliminar todas</button>
             </form>
         </div>
@@ -326,6 +328,7 @@
                 <div class="fecha" th:text="${#temporals.format(a.fechaCreacion.toInstant(), 'dd/MM/yyyy HH:mm')}"></div>
             </div>
             <form class="acciones" th:action="@{/alertas/eliminar}" method="post">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <input type="hidden" name="id" th:value="${a.id}" />
                 <button type="submit" class="btn-toggle">Eliminar</button>
             </form>
@@ -344,6 +347,7 @@
         <div class="modal">
             <h2>Nueva Alarma</h2>
             <form th:action="@{/alertas/guardar}" method="post">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <label for="alert-estacion">Estación</label>
                 <select id="alert-estacion" name="estacion">
                     <option th:each="e : ${estaciones}" th:value="${e.id}" th:text="${e.nombre}"></option>

--- a/app/src/main/resources/templates/dashboard.html
+++ b/app/src/main/resources/templates/dashboard.html
@@ -344,6 +344,7 @@
         </ul>
     </nav>
     <form class="logout-form" th:action="@{/logout}" method="post" style="margin-top: 20px;">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
         <button type="submit">Cerrar sesión</button>
     </form>
 </div>

--- a/app/src/main/resources/templates/editarEstacion.html
+++ b/app/src/main/resources/templates/editarEstacion.html
@@ -137,6 +137,7 @@
     <div th:replace="fragments/alertasActivas :: alertas"></div>
     <p class="subtitle">Modifica la información de la estación</p>
     <form th:action="@{/estaciones/editar}" th:object="${estacion}" method="post">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
         <label>ID</label>
         <input type="text" th:field="*{id}" readonly />
 

--- a/app/src/main/resources/templates/estaciones.html
+++ b/app/src/main/resources/templates/estaciones.html
@@ -158,6 +158,7 @@
         </ul>
     </nav>
     <form class="logout-form" th:action="@{/logout}" method="post">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
         <button type="submit">Cerrar sesión</button>
     </form>
 </div>

--- a/app/src/main/resources/templates/form-estacion.html
+++ b/app/src/main/resources/templates/form-estacion.html
@@ -136,6 +136,7 @@
     <div th:replace="fragments/alertasActivas :: alertas"></div>
     <p class="subtitle">Completa la información de la estación</p>
     <form th:action="@{${estacion.id} == null ? '/estaciones/nueva' : '/estaciones/editar'}" th:object="${estacion}" method="post">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
         <label for="id">ID</label>
         <input type="text" id="id" th:field="*{id}" placeholder="ID de la estación" required />
 

--- a/app/src/main/resources/templates/login.html
+++ b/app/src/main/resources/templates/login.html
@@ -149,6 +149,7 @@
 
     <form th:action="@{/login}" method="post">
         <div th:if="${param.error}" class="error">Usuario o contraseña incorrectos</div>
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
         <input type="text" name="username" placeholder="Usuario" required>
         <input type="password" name="password" placeholder="Contraseña" required>
         <button type="submit">

--- a/app/src/main/resources/templates/reportePreview.html
+++ b/app/src/main/resources/templates/reportePreview.html
@@ -46,6 +46,7 @@
             </ul>
         </nav>
         <form class="logout-form" th:action="@{/logout}" method="post">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
             <button type="submit">Cerrar sesión</button>
         </form>
     </div>

--- a/app/src/main/resources/templates/reportes.html
+++ b/app/src/main/resources/templates/reportes.html
@@ -126,6 +126,7 @@
             </ul>
         </nav>
         <form class="logout-form" th:action="@{/logout}" method="post">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
             <button type="submit">Cerrar sesión</button>
         </form>
     </div>
@@ -143,6 +144,7 @@
                 <p><strong>Generar Reporte:</strong> Crea un reporte meteorológico con los filtros seleccionados.</p>
             </div>
             <form method="post" th:action="@{/reportes}" id="reporteForm">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <div class="field">
                     <label for="fecha">Fecha:</label>
                     <input type="date" id="fecha" name="fecha" th:value="${fecha}" />

--- a/app/src/main/resources/templates/tablas.html
+++ b/app/src/main/resources/templates/tablas.html
@@ -52,6 +52,7 @@
       </ul>
     </nav>
     <form class="logout-form" th:action="@{/logout}" method="post">
+      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
       <button type="submit">Cerrar sesión</button>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- add CSRF hidden input to login form to prevent endless redirect loops during login

## Testing
- `./gradlew test` *(fails: Unable to download dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687ffc21eb0c8322bd2ae6b700806fe4