### PR TITLE
Increase inactive timeout

### DIFF
--- a/app/src/main/java/org/javadominicano/controladores/VisualizadorController.java
+++ b/app/src/main/java/org/javadominicano/controladores/VisualizadorController.java
@@ -194,9 +194,9 @@ public class VisualizadorController {
             repositorioHumedadSuelo.findTopByOrderByFechaDesc(PageRequest.of(0,1)).get(0).getHumedad()
         );
 
-        // Fecha límite para considerar una estación activa (12 segundos)
+        // Fecha límite para considerar una estación activa (20 segundos)
         Date ahora = new Date();
-        Date fechaLimite = new Date(ahora.getTime() - 12_000L);
+        Date fechaLimite = new Date(ahora.getTime() - 20_000L);
 
         List<EstacionMeteorologica> todasEstaciones = repositorioEstacion.findAll();
         int estacionesActivas = 0;
@@ -335,7 +335,7 @@ public class VisualizadorController {
     @GetMapping("/estaciones")
     public String listarEstaciones(Model model) {
         Date ahora = new Date();
-        Date fechaLimite = new Date(ahora.getTime() - 12_000L);
+        Date fechaLimite = new Date(ahora.getTime() - 20_000L);
 
         int estacionesActivas = 0;
         int estacionesInactivas = 0;

--- a/app/src/main/java/org/servicios/EstadoEstacionesService.java
+++ b/app/src/main/java/org/servicios/EstadoEstacionesService.java
@@ -35,7 +35,8 @@ public class EstadoEstacionesService {
 
     public List<EstadoEstacionDTO> obtenerEstados() {
         Date ahora = new Date();
-        Date limite = new Date(ahora.getTime() - 12_000L);
+        // Considerar la estación como activa si reportó en los últimos 20 segundos
+        Date limite = new Date(ahora.getTime() - 20_000L);
         List<EstadoEstacionDTO> lista = new ArrayList<>();
         for (EstacionMeteorologica e : repoEstacion.findAll()) {
             Date ultima = obtenerUltimaFechaEstacion(e.getId());

--- a/app/src/main/resources/templates/dashboard.html
+++ b/app/src/main/resources/templates/dashboard.html
@@ -662,8 +662,8 @@ function updateCharts() {
         });
 }
 
-// Actualizar gráficas cada 12 segundos con datos reales
-setInterval(updateCharts, 12000);
+// Actualizar gráficas cada 20 segundos con datos reales
+setInterval(updateCharts, 20000);
 
 // Actualizar inmediatamente al cargar la página
 updateCharts();

--- a/app/src/main/resources/templates/fragments/alertasActivas.html
+++ b/app/src/main/resources/templates/fragments/alertasActivas.html
@@ -98,7 +98,7 @@
     }
 
     checkEstados();
-    setInterval(checkEstados, 12000);
+    setInterval(checkEstados, 20000);
 
     function mensajeAlerta(a) {
         switch(a.alerta.nombre) {


### PR DESCRIPTION
## Summary
- change inactivity timeout to 20 seconds
- sync UI refresh intervals to 20 seconds

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68897be5cbb483229fded83b1b0e9f1f