### PR TITLE
Configure forwarded headers for websockets

### DIFF
--- a/app/src/main/java/org/javadominicano/configuracion/ForwardedHeaderConfig.java
+++ b/app/src/main/java/org/javadominicano/configuracion/ForwardedHeaderConfig.java
@@ -1,0 +1,13 @@
+package org.javadominicano.configuracion;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.ForwardedHeaderFilter;
+
+@Configuration
+public class ForwardedHeaderConfig {
+    @Bean
+    public ForwardedHeaderFilter forwardedHeaderFilter() {
+        return new ForwardedHeaderFilter();
+    }
+}

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -15,3 +15,6 @@ spring.thymeleaf.suffix=.html
 spring.thymeleaf.mode=HTML
 spring.thymeleaf.encoding=UTF-8
 spring.thymeleaf.cache=false
+
+# Enable forward headers for proxies
+server.forward-headers-strategy=native


### PR DESCRIPTION
## Summary
- add `ForwardedHeaderConfig` bean so Spring processes `X-Forwarded-*` headers when behind a proxy
- enable forwarding strategy in `application.properties`

## Testing
- `./gradlew -p app test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68899888737083229b23a5768cd657bd