### PR TITLE
Increase alert notification duration

### DIFF
--- a/app/src/main/resources/templates/fragments/alertasActivas.html
+++ b/app/src/main/resources/templates/fragments/alertasActivas.html
@@ -56,7 +56,7 @@
         if (btn) {
             btn.addEventListener('click', markAsShown);
         }
-        setTimeout(markAsShown, 7000);
+        setTimeout(markAsShown, 10000);
     });
 
     function mostrarAlertaEstado(nombre, activa) {
@@ -77,7 +77,7 @@
         cont.appendChild(card);
         var remove = function() { card.remove(); };
         btn.addEventListener('click', remove);
-        setTimeout(remove, 7000);
+        setTimeout(remove, 10000);
     }
 
     function checkEstados() {
@@ -142,7 +142,7 @@
 
         var remove = function() { card.remove(); };
         btn.addEventListener('click', function(){ localStorage.setItem(key, 'shown'); remove(); });
-        setTimeout(function(){ localStorage.setItem(key, 'shown'); remove(); }, 7000);
+        setTimeout(function(){ localStorage.setItem(key, 'shown'); remove(); }, 10000);
     }
 
     function actualizarAlertas(lista) {


### PR DESCRIPTION
## Summary
- increase automatic dismissal timer for alert notifications to 10s

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688ad68d943c8322bc347f17c74cc922